### PR TITLE
update targets for xp

### DIFF
--- a/Targets/LnkFilesAndJumpLists.tkape
+++ b/Targets/LnkFilesAndJumpLists.tkape
@@ -39,3 +39,10 @@ Targets:
         IsDirectory: false
         Recursive: false
         Comment: ""
+    -
+        Name: Restore point lnk files XP
+        Category: LnkFiles
+        Path: C:\System Volume Information\_restore*\RP*\*.lnk
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/RegistryHives.tkape
+++ b/Targets/RegistryHives.tkape
@@ -179,3 +179,10 @@ Targets:
         IsDirectory: false
         Recursive: false
         Comment: ""
+    -
+        Name: System Restore Points Registry Hives (XP)
+        Category: Registry
+        Path: C:\System Volume Information\_restore*\RP*\snapshot\_REGISTRY_*
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/XPRestorePoints.tkape
+++ b/Targets/XPRestorePoints.tkape
@@ -1,0 +1,13 @@
+Description: XP Restore Points - System Volume Information directory
+Author: Phill Moore
+Version: 1
+Id: 07f57a75-f9d9-42f3-842c-bd7e5abbb569
+RecreateDirectories: true
+Targets:
+    -
+        Name: System Volume Information
+        Category: Folder capture
+        Path: C:\System Volume Information
+        IsDirectory: true
+        Recursive: true
+        Comment: ""


### PR DESCRIPTION
updated targets to capture information in XP Restore Points
RegistryHives and LNKFilesAndJumpLists now captures from System Volume Information
or just capture all of XPRestorePoints