### PR TITLE
Add Cisco Jabber target file.

### DIFF
--- a/Targets/CiscoJabber.tkape
+++ b/Targets/CiscoJabber.tkape
@@ -1,0 +1,13 @@
+Description: Jabber
+Author: Andrew Bannon
+Version: 1.0
+Id: xmHqCTwz-nH1w-HW5k-szku-wstWcz8Ds0
+RecreateDirectories: true
+Targets:
+    -
+        Name: Cisco Jabber Database
+        Category: Communications
+        Path: C:\Users\*\AppData\Local\Cisco\Unified Communications\Jabber\CSF\History\*.db
+        IsDirectory: false
+        Recursive: false
+        Comment: "The Cisco Jabber process needs to be killed before database can be copied."

--- a/Targets/CiscoJabber.tkape
+++ b/Targets/CiscoJabber.tkape
@@ -1,7 +1,7 @@
 Description: Jabber
 Author: Andrew Bannon
 Version: 1.0
-Id: xmHqCTwz-nH1w-HW5k-szku-wstWcz8Ds0
+Id: 69249cc7-2b04-47c4-8ba9-d8055fadc950
 RecreateDirectories: true
 Targets:
     -


### PR DESCRIPTION
Not sure how many people will find use out of this, but pulling Jabber chat logs could be helpful for anyone who uses it in their enterprise. 