### PR TITLE
Get-DoSvcExternalIP module

### DIFF
--- a/Modules/Get-DoSvcExternalIP.mkape
+++ b/Modules/Get-DoSvcExternalIP.mkape
@@ -1,0 +1,18 @@
+Description: 'Get-DoSvcExternalIP: extracts public IP addresses from DoSvc EventTraceLogs'
+Category: SystemActivity
+Author: Gabriele Zambelli
+Version: 1
+Id: fc01eeb0-2e2d-4fbe-96b8-02a64933d466
+BinaryUrl: https://raw.githubusercontent.com/forensenellanebbia/powershell-scripts/master/Get-DoSvcExternalIP.ps1
+ExportFormat: csv
+Processors:
+    -
+        Executable: C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: -Command "%kapedirectory%\Modules\bin\Get-DoSvcExternalIP.ps1 %sourceDirectory% -NoIP2Location -OutputPath %destinationDirectory%"
+        ExportFormat: csv
+#####
+# Get-DoSvcExternalIP extracts public IP addresses of a Windows 10 device from DoSvc EventTraceLogs
+# https://raw.githubusercontent.com/forensenellanebbia/powershell-scripts/master/Get-DoSvcExternalIP.ps1
+# Get-DoSvcExternalIP.ps1 must be in Modules\bin folder
+# Example: .\kape.exe --msource D:\kape\C --mdest D:\kape\out --module Get-DoSvcExternalIP
+#####


### PR DESCRIPTION
This module uses my powershell script to parse DoSvc event trace logs and extract the public IP addresses previously used by the device. 