### PR TITLE
add simple regripper modules

### DIFF
--- a/Modules/RegRipper-ntuser.mkape
+++ b/Modules/RegRipper-ntuser.mkape
@@ -1,0 +1,17 @@
+Description: 'RegRipper: parse NTUSER hives'
+Category: Registry
+Author: ZeArioch
+Version: 1
+Id: ce3bf979-0d4d-4a31-8240-6be6f95610b7
+BinaryUrl: https://github.com/keydet89/RegRipper2.8
+##
+## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
+##
+ExportFormat: txt
+FileMask: ntuser.dat
+Processors:
+    -
+        Executable: rip.exe
+        CommandLine: -r %sourceFile% -f ntuser
+        ExportFormat: txt
+        ExportFile: regripper-ntuser.txt

--- a/Modules/RegRipper-sam.mkape
+++ b/Modules/RegRipper-sam.mkape
@@ -1,0 +1,17 @@
+Description: 'RegRipper: parse SAM hive'
+Category: Registry
+Author: ZeArioch
+Version: 1
+Id: 4b1babd2-c7e1-4f1f-a34f-1968d3672752
+BinaryUrl: https://github.com/keydet89/RegRipper2.8
+##
+## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
+##  
+ExportFormat: txt
+FileMask: SAM
+Processors:
+    -
+        Executable: rip.exe
+        CommandLine: -r %sourceFile% -f sam
+        ExportFormat: txt
+        ExportFile: regripper-sam.txt

--- a/Modules/RegRipper-security.mkape
+++ b/Modules/RegRipper-security.mkape
@@ -1,0 +1,17 @@
+Description: 'RegRipper: parse SECURITY hive'
+Category: Registry
+Author: ZeArioch
+Version: 1
+Id: a0011605-10ac-4e7b-b422-8d1afeebfd5c
+BinaryUrl: https://github.com/keydet89/RegRipper2.8
+##
+## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
+##
+ExportFormat: txt
+FileMask: SECURITY
+Processors:
+    -
+        Executable: rip.exe
+        CommandLine: -r %sourceFile% -f security
+        ExportFormat: txt
+        ExportFile: regripper-security.txt

--- a/Modules/RegRipper-software.mkape
+++ b/Modules/RegRipper-software.mkape
@@ -1,0 +1,17 @@
+Description: 'RegRipper: parse SOFTWARE hive'
+Category: Registry
+Author: ZeArioch
+Version: 1
+Id: 8fa920ff-03ce-4f88-af2a-0558187f708c
+BinaryUrl: https://github.com/keydet89/RegRipper2.8
+##
+## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
+##
+ExportFormat: txt
+FileMask: SOFTWARE
+Processors:
+    -
+        Executable: rip.exe
+        CommandLine: -r %sourceFile% -f software
+        ExportFormat: txt
+        ExportFile: regripper-software.txt

--- a/Modules/RegRipper-system.mkape
+++ b/Modules/RegRipper-system.mkape
@@ -1,0 +1,17 @@
+Description: 'RegRipper: parse SYSTEM hive'
+Category: Registry
+Author: ZeArioch
+Version: 1
+Id: ef988f41-7d77-436d-bc1a-1789f062506b
+BinaryUrl: https://github.com/keydet89/RegRipper2.8
+##
+## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
+##
+ExportFormat: txt
+FileMask: SYSTEM
+Processors:
+    -
+        Executable: rip.exe
+        CommandLine: -r %sourceFile% -f system
+        ExportFormat: txt
+        ExportFile: regripper-system.txt


### PR DESCRIPTION
Generate RegRipper reports from collected registry hives.
Successfully tested against an example image.

`.\kape.exe --tsource "<SRC>" --tdest "<DST>" --tflush --target RegistryHives --mdest "<MDST>" --mflush --module RegRipper-ntuser,RegRipper-sam,RegRipper-security,RegRipper-software,RegRipper-system`