### PR TITLE
Update RegRipper modules

### DIFF
--- a/Modules/RegRipper-ALL.mkape
+++ b/Modules/RegRipper-ALL.mkape
@@ -1,0 +1,34 @@
+Description: 'RegRipper: parse all supported hives'
+Category: Registry
+Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
+Version: 1
+Id: 76037ee9-0346-459a-a44a-1b67edc711c8
+BinaryUrl: https://github.com/keydet89/RegRipper2.8
+ExportFormat: txt
+FileMask: ""
+Processors:
+    -
+        Executable: RegRipper-sam.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: RegRipper-security.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: RegRipper-software.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: RegRipper-system.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: RegRipper-ntuser.mkape
+        CommandLine: ""
+        ExportFormat: ""
+
+##
+## Create a folder "regripper" within the "Modules\bin" KAPE folder
+## Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+##

--- a/Modules/RegRipper-ntuser.mkape
+++ b/Modules/RegRipper-ntuser.mkape
@@ -1,17 +1,19 @@
 Description: 'RegRipper: parse NTUSER hives'
 Category: Registry
-Author: ZeArioch
-Version: 1
+Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
+Version: 1.1
 Id: ce3bf979-0d4d-4a31-8240-6be6f95610b7
 BinaryUrl: https://github.com/keydet89/RegRipper2.8
-##
-## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
-##
 ExportFormat: txt
 FileMask: ntuser.dat
 Processors:
     -
-        Executable: rip.exe
+        Executable: regripper\rip.exe
         CommandLine: -r %sourceFile% -f ntuser
         ExportFormat: txt
         ExportFile: regripper-ntuser.txt
+
+##
+## Create a folder "regripper" within the "Modules\bin" KAPE folder
+## Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+##

--- a/Modules/RegRipper-sam.mkape
+++ b/Modules/RegRipper-sam.mkape
@@ -1,17 +1,19 @@
 Description: 'RegRipper: parse SAM hive'
 Category: Registry
-Author: ZeArioch
-Version: 1
+Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
+Version: 1.1
 Id: 4b1babd2-c7e1-4f1f-a34f-1968d3672752
 BinaryUrl: https://github.com/keydet89/RegRipper2.8
-##
-## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
-##  
 ExportFormat: txt
 FileMask: SAM
 Processors:
     -
-        Executable: rip.exe
+        Executable: regripper\rip.exe
         CommandLine: -r %sourceFile% -f sam
         ExportFormat: txt
         ExportFile: regripper-sam.txt
+
+##
+## Create a folder "regripper" within the "Modules\bin" KAPE folder
+## Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+##

--- a/Modules/RegRipper-security.mkape
+++ b/Modules/RegRipper-security.mkape
@@ -1,17 +1,19 @@
 Description: 'RegRipper: parse SECURITY hive'
 Category: Registry
-Author: ZeArioch
-Version: 1
+Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
+Version: 1.1
 Id: a0011605-10ac-4e7b-b422-8d1afeebfd5c
 BinaryUrl: https://github.com/keydet89/RegRipper2.8
-##
-## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
-##
 ExportFormat: txt
 FileMask: SECURITY
 Processors:
     -
-        Executable: rip.exe
+        Executable: regripper\rip.exe
         CommandLine: -r %sourceFile% -f security
         ExportFormat: txt
         ExportFile: regripper-security.txt
+
+##
+## Create a folder "regripper" within the "Modules\bin" KAPE folder
+## Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+##

--- a/Modules/RegRipper-software.mkape
+++ b/Modules/RegRipper-software.mkape
@@ -1,17 +1,19 @@
 Description: 'RegRipper: parse SOFTWARE hive'
 Category: Registry
-Author: ZeArioch
-Version: 1
+Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
+Version: 1.1
 Id: 8fa920ff-03ce-4f88-af2a-0558187f708c
 BinaryUrl: https://github.com/keydet89/RegRipper2.8
-##
-## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
-##
 ExportFormat: txt
 FileMask: SOFTWARE
 Processors:
     -
-        Executable: rip.exe
+        Executable: regripper\rip.exe
         CommandLine: -r %sourceFile% -f software
         ExportFormat: txt
         ExportFile: regripper-software.txt
+
+##
+## Create a folder "regripper" within the "Modules\bin" KAPE folder
+## Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+##

--- a/Modules/RegRipper-system.mkape
+++ b/Modules/RegRipper-system.mkape
@@ -1,17 +1,19 @@
 Description: 'RegRipper: parse SYSTEM hive'
 Category: Registry
-Author: ZeArioch
-Version: 1
+Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
+Version: 1.1
 Id: ef988f41-7d77-436d-bc1a-1789f062506b
 BinaryUrl: https://github.com/keydet89/RegRipper2.8
-##
-## Place rip.exe, p2x5124.dll and the plugins folder into Modules\bin
-##
 ExportFormat: txt
 FileMask: SYSTEM
 Processors:
     -
-        Executable: rip.exe
+        Executable: regripper\rip.exe
         CommandLine: -r %sourceFile% -f system
         ExportFormat: txt
         ExportFile: regripper-system.txt
+
+##
+## Create a folder "regripper" within the "Modules\bin" KAPE folder
+## Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+##


### PR DESCRIPTION
Update RegRipper files location (props to @randomaccess3 for the suggestion) to make the KAPE modules\bin folder cleaner, and added "ALL" meta-module for RegRipper.