### PR TITLE
Added targets for Exchange logs

### DIFF
--- a/Targets/Exchange.tkape
+++ b/Targets/Exchange.tkape
@@ -1,0 +1,20 @@
+Description: Exchange Log Files
+Author: Keith Twombley
+Version: 1
+Id: 1b54aafe-5074-4d45-b129-29107ce7f863
+RecreateDirectories: true
+Targets:
+    -
+        Name: Exchange client access log files
+        Category: Logs
+        Path: ExchangeClientAccess.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: Exchange TransportRoles log files
+        Category: Logs
+        Path: ExchangeTransport.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/ExchangeClientAccess.tkape
+++ b/Targets/ExchangeClientAccess.tkape
@@ -1,0 +1,15 @@
+Description: Exchange Client Access Log Files
+Author: Keith Twombley
+Version: 1
+Id: 9e802154-53eb-4cc9-9cca-d2e39f3227d7
+RecreateDirectories: true
+Targets:
+    -
+        Name: Exchange client access log files
+        Category: Logs
+        Path: C:\Program Files\Microsoft\Exchange Server\*\Logging
+        IsDirectory: true
+        Recursive: true
+        FileMask: '*.log'
+        Comment: "Highly dependent on Exchange configuration"
+

--- a/Targets/ExchangeTransport.tkape
+++ b/Targets/ExchangeTransport.tkape
@@ -1,0 +1,15 @@
+Description: Exchange Transport Log Files
+Author: Keith Twombley
+Version: 1
+Id: 9bc0a453-50ab-46e8-a424-09dc7022c4a4
+RecreateDirectories: true
+Targets:
+    -
+        Name: Exchange TransportRoles log files
+        Category: Logs
+        Path: C:\Program Files\Microsoft\Exchange Server\*\TransportRoles\Logs\
+        IsDirectory: true
+        Recursive: true
+        FileMask: '*.log'
+        Comment: "Highly dependent on Exchange configuration"
+


### PR DESCRIPTION
Added targets for Exchange client access logs and transport logs.

Also added an overall Exchange.tkape referencing the two others.