### PR TITLE
Add target for detached signature files

### DIFF
--- a/Targets/SignatureCatalog.tkape
+++ b/Targets/SignatureCatalog.tkape
@@ -1,0 +1,28 @@
+Description: Obtain detached signature catalog files
+Author: Mike Pilkington
+Version: 1
+Id: 953b16e8-69ea-4967-9f9b-bcfa4f4fbe7b
+RecreateDirectories: true
+Targets:
+    -
+        Name: SignatureCatalog
+        Category: FileMetadata
+        Path: C:\Windows\System32\CatRoot
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+        
+## USE CASE ##
+# Validating digital signatures of an offline system can be problematic.  
+# Microsoft relies mostly on detached signature files to sign Windows 
+# executables.  Checking those on an offline system using sigcheck.exe
+# from SysInternals requires importing the target system's detached 
+# signature files into the anlysis system.  To use with sigcheck, slightly 
+# rename the collected GUID directories (keeping the names in a GUID format), 
+# copy them to C:\Windows\System32\CatRoot of your analysis machine, restart 
+# Cryptographic Services, then run sigcheck against the target system files.  
+# This will import the target's signature files into the local analysis 
+# machine's signature database and should accurately validate the target 
+# system's files (which presumabley were collected with other KAPE modules).
+# Kudos to Troy Larson for providing this workaround technique.
+##


### PR DESCRIPTION
Eric, I've tested the process to extract the cat files from the suspect system with this target file and then imported them into the analysis machine. Works like a charm!  FYI, it will be in the new 508 ex 1.3.  Thanks to you and Troy for pointing out the process.  

New target file here to get the necessary directories from C:\Windows\System32\CatRoot.  And this target file has a new/unique ID.

-Mike