### PR TITLE
Fix typo within "!BasicCollection.tkape"

### DIFF
--- a/Targets/!BasicCollection.tkape
+++ b/Targets/!BasicCollection.tkape
@@ -42,7 +42,7 @@ Targets:
     -
         Name: PowerShellConsole
         Category: Evidence Of Execution
-        Path: LnkFilesAndJumpLists.tkape
+        Path: PowerShellConsole.tkape
         IsDirectory: false
         Recursive: false
         Comment: ""


### PR DESCRIPTION
"PowerShellConsole" target had the wrong path (probably a mistake due to copy & paste)