### PR TITLE
Winpmem updates

### DIFF
--- a/Modules/WinPmem.mkape
+++ b/Modules/WinPmem.mkape
@@ -1,12 +1,24 @@
 Description: WinPmem Memory Dump
 Category: Memory
 Author: Eric Capuano 
-Version: 2
+Version: 3
 Id: 1d284835-417b-459e-a396-d228edea3808
 BinaryUrl: https://github.com/Velocidex/c-aff4/releases/download/3.2/winpmem_3.2.exe
 ExportFormat: dmp
 Processors:
     -
-        Executable: winpmem_3.2.exe
-        CommandLine: "-o %destinationDirectory%/memory.dmp --volume_format raw -dd"
+        Executable: winpmem.exe
+        CommandLine: "-o %destinationDirectory%//memory.dmp --volume_format raw --format raw -dd --logfile %destinationDirectory%//winpmem.log"
         ExportFormat: dmp
+
+### README
+#
+# 1. Download winpmem_3.2.exe using the link above; also tested with winpmem_3.3.rc1.exe. Other versions may work, but are untested.
+# 2. Rename the binary to winpmem.exe (dropping the version number) 
+# 3. Place the binary into '<KAPE_working_directory>/Modules/bin'
+#   - KAPE should now be able to find the executable at '<KAPE_working_directory>/Modules/bin/winpmem.exe'
+#
+# To obtain a compressed AFF4 memory dump, swap `--format raw` for `--format map` in the command line parameter above.
+#
+# Example usage: 
+# kape.exe --tsource C --target EventLogs --tdest "c:\temp\tdest" --module WinPmem --mdest "c:\temp\mdest" --mflush --tflush

--- a/Modules/WinPmem.mkape
+++ b/Modules/WinPmem.mkape
@@ -8,7 +8,7 @@ ExportFormat: dmp
 Processors:
     -
         Executable: winpmem.exe
-        CommandLine: "-o %destinationDirectory%//memory.dmp --volume_format raw --format raw -dd --logfile %destinationDirectory%//winpmem.log"
+        CommandLine: "-o %destinationDirectory%\\memory.dmp --volume_format raw --format raw -dd --logfile %destinationDirectory%\\winpmem.log"
         ExportFormat: dmp
 
 ### README


### PR DESCRIPTION
Added winpmem logging to file, additional `--format raw` options for compatibility with winpmem 3.3rc1 which defaults to `map` I believe. and made the executable name version agnostic. Also added a small readme.

Tested with both winpmem 3.2 and 3.3rc1

![image](https://user-images.githubusercontent.com/4219694/61171707-7c7e8800-a573-11e9-8bbc-d06b7650861b.png)
