### PR TITLE
Add files via upload

### DIFF
--- a/Modules/Snap2HTML.mkape
+++ b/Modules/Snap2HTML.mkape
@@ -6,18 +6,15 @@ Id: 0ca2b18d-b886-497c-a57a-ea4442c878e2
 BinaryUrl: https://www.rlvision.com/script/download.php?ref=rlv.com&file=Snap2HTML.zip
 ExportFormat: html
 Processors:
-    -
-        Executable: Snap2HTML/Snap2HTML.exe
-        CommandLine: -path:""%sourceDirectory%""  -outfile:""%destinationDirectory%/Kape_Processed.html"" -title:"KAPE Processed Directories" -hidden -system
-        ExportFormat: html
-        ExportFile:
+-
+       Executable: Snap2HTML/Snap2HTML.exe
+       CommandLine: -path:%sourceDirectory% -outfile:%destinationDirectory%/Kape_Processed.html -title:"KAPE Processed Directories" -hidden -system
+       ExportFormat: html
 
 
 ######
 # Module uses Snap2HTML to export a browseable HTML directory.
 # Software author: RL Vision (Snap2HTML)
-# Requires "Target Source" to function.
-# This module should be utilized with the Target & Module options selected.
-# Options available: -hidden (Include hidden files) | -system (Include system files) | -title (title of HTML file)
+# Options available: -hidden (Include hidden files) | -system (Include system files) | -title (title of HTML file) | -link (link to path)
 # HTML located at Snap2HTML/template.html can be customized.
 ######

--- a/Modules/Snap2HTML.mkape
+++ b/Modules/Snap2HTML.mkape
@@ -1,0 +1,23 @@
+Description: 'Directory Lister - HTML Browser'
+Category: DirectoryLister
+Author: Dennis Reneau
+Version: 1
+Id: 0ca2b18d-b886-497c-a57a-ea4442c878e2
+BinaryUrl: https://www.rlvision.com/script/download.php?ref=rlv.com&file=Snap2HTML.zip
+ExportFormat: html
+Processors:
+    -
+        Executable: Snap2HTML/Snap2HTML.exe
+        CommandLine: -path:""%sourceDirectory%""  -outfile:""%destinationDirectory%/Kape_Processed.html"" -title:"KAPE Processed Directories" -hidden -system
+        ExportFormat: html
+        ExportFile:
+
+
+######
+# Module uses Snap2HTML to export a browseable HTML directory.
+# Software author: RL Vision (Snap2HTML)
+# Requires "Target Source" to function.
+# This module should be utilized with the Target & Module options selected.
+# Options available: -hidden (Include hidden files) | -system (Include system files) | -title (title of HTML file)
+# HTML located at Snap2HTML/template.html can be customized.
+######


### PR DESCRIPTION
Module used to create an HTML directory browser of the Target Directory or Module Source.

I ran the --mlist --mdtail and the module has a new ID. Can you please confirm there is no issue with the double"" around ""%sourceDirectory%""? 

The program actually requires the settings files located within the zip, so I did not point to the binary URL.
https://www.rlvision.com/script/download.php?ref=rlv.com&file=Snap2HTML.zip

Thank you.