### PR TITLE
Update GUIDs & added event_ids - EventLogs-RDP.tkape & EvtxECmd-RDP.mkape

### DIFF
--- a/Modules/EvtxECmd-RDP.mkape
+++ b/Modules/EvtxECmd-RDP.mkape
@@ -1,20 +1,20 @@
 Description: 'EvtxECmd: process event log files'
 Category: EventLogs
-Author: Eric Zimmerman
+Author: Mark Hallman
 Version: 1
-Id: 1b66f0e2-2ccf-467d-ae15-a2b3dc59df08
+Id: d6ddc918-feb1-47b6-8e51-e9c50936ec75
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
 ExportFormat: csv
 Processors:
     -
         Executable: EvtxECmd\EvtxECmd.exe
-        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% --inc %evtx_id% 
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% --inc "3,21,22,23,24,25,59,60,98,100,102,104,106,119,131,140,141,169,200,201,261,300,307,500,505,1000,1001,1002,1024,1027,1033,1034,1102,1149,4104,4105,4106,4624,4625,4634,4647,4648,4661,4662,4663,4672,4688,4697,4698,4699,4700,4701,4702,4719,4720,4738,4768,4769,4771,4776,4778,4779,4798,4799,4800,4801,4802,4803,5136,5140,5142,5144,5145,5156,5857,5860,5861,6005,6006,7034,7035,7036,7040,7045,10000,10001,11707,11708,11724"
         ExportFormat: csv
     -
         Executable: EvtxECmd\EvtxECmd.exe
-        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% --inc %evtx_id%
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% --inc "3,21,22,23,24,25,59,60,98,100,102,104,106,119,131,140,141,169,200,201,261,300,307,500,505,1000,1001,1002,1024,1027,1033,1034,1102,1149,4104,4105,4106,4624,4625,4634,4647,4648,4661,4662,4663,4672,4688,4697,4698,4699,4700,4701,4702,4719,4720,4738,4768,4769,4771,4776,4778,4779,4798,4799,4800,4801,4802,4803,5136,5140,5142,5144,5145,5156,5857,5860,5861,6005,6006,7034,7035,7036,7040,7045,10000,10001,11707,11708,11724"
         ExportFormat: xml
     -
         Executable: EvtxECmd\EvtxECmd.exe
-        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% --inc %evtx_id%
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% --inc "3,21,22,23,24,25,59,60,98,100,102,104,106,119,131,140,141,169,200,201,261,300,307,500,505,1000,1001,1002,1024,1027,1033,1034,1102,1149,4104,4105,4106,4624,4625,4634,4647,4648,4661,4662,4663,4672,4688,4697,4698,4699,4700,4701,4702,4719,4720,4738,4768,4769,4771,4776,4778,4779,4798,4799,4800,4801,4802,4803,5136,5140,5142,5144,5145,5156,5857,5860,5861,6005,6006,7034,7035,7036,7040,7045,10000,10001,11707,11708,11724"
         ExportFormat: json

--- a/Targets/EventLogs-RDP.tkape
+++ b/Targets/EventLogs-RDP.tkape
@@ -1,7 +1,7 @@
 Description: Collect Win7+ RDP related Event logs
 Author: Markk Hallman
 Version: 1
-Id: d95784d9-bd1c-472b-aeef-de5d9ecc7aaa
+Id: 2e79fc64-816c-439a-8b7f-93dd59bf2711
 RecreateDirectories: true
 Targets:
     -


### PR DESCRIPTION
I have updated the GUIDs on both EventLogs-RDP.tkape & EvtxECmd-RDP.mkape... Pretty sure that they were already unique but just being careful.

I have added the list of RDP specific event_id's directly to EvtxECmd-RDP.mkape so that they are not needed on the command line.   EvtxECmd-RDP.mkape now has no command-line vars that require the use of the --mvars option.  

Kape command line to use both:

```kape.exe --target EventLogs-RDP --tsource <your-source> --tdest <your-target-dest> --mdest <your-module-dest> --module EvtxECmd-RDP```