### PR TITLE
Add/update antivirus targets

### DIFF
--- a/Targets/Antivirus.tkape
+++ b/Targets/Antivirus.tkape
@@ -1,0 +1,111 @@
+Description: Composite target for files related to Antivirus tools
+Author: Drew Ervin
+Version: 1.1
+Id: c989b822-b4ff-47fc-90e1-b45cc5add822
+RecreateDirectories: true
+Targets:
+    -
+        Name: Avast
+        Category: Antivirus
+        Path: Avast.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: Bitdefender
+        Category: Antivirus
+        Path: Bitdefender.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: ComboFix
+        Category: Antivirus
+        Path: ComboFix.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: ESET
+        Category: Antivirus
+        Path: ESET.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: F-Secure
+        Category: Antivirus
+        Path: FSecure.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: HitmanPro
+        Category: Antivirus
+        Path: HitmanPro.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: Malwarebytes
+        Category: Antivirus
+        Path: Malwarebytes.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: McAfee
+        Category: Antivirus
+        Path: McAfee.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: RogueKiller
+        Category: Antivirus
+        Path: RogueKiller.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: Sophos
+        Category: Antivirus
+        Path: Sophos.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: SUPERAntiSpyware
+        Category: Antivirus
+        Path: SUPERAntiSpyware.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: Symantec
+        Category: Antivirus
+        Path: Symantec_AV_Logs.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: Trend Micro
+        Category: Antivirus
+        Path: TrendMicro.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: VIPRE
+        Category: Antivirus
+        Path: VIPRE.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: Windows Defender
+        Category: Antivirus
+        Path: WindowsDefender.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/Avast.tkape
+++ b/Targets/Avast.tkape
@@ -1,0 +1,34 @@
+Description: Avast Antivirus Data
+Author: Drew Ervin
+Version: 1.0
+Id: 8b625ea2-fafa-46be-8ba1-15efd1de2a53
+RecreateDirectories: true
+Targets:
+    -
+        Name: Avast AV Logs (XP)
+        Category: Antivirus
+        Path: C:\Documents And Settings\All Users\Application Data\Avast Software\Avast\Log
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: Avast AV Logs
+        Category: Antivirus
+        Path: C:\ProgramData\Avast Software\Avast\Log\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: Avast AV User Logs
+        Category: Antivirus
+        Path: C:\Users\*\Avast Software\Avast\Log
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: Avast AV Index
+        Category: Antivirus
+        Path: C:\ProgramData\Avast Software\Avast\Chest\index.xml
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/Bitdefender.tkape
+++ b/Targets/Bitdefender.tkape
@@ -1,0 +1,13 @@
+Description: Bitdefender Antivirus Data
+Author: Drew Ervin
+Version: 1.0
+Id: e48c32bf-4069-4f79-acac-4ed181fa84c9
+RecreateDirectories: true
+Targets:
+    -
+        Name: Bitdefender Endpoint Security Logs
+        Category: Antivirus
+        Path: C:\ProgramData\Bitdefender\Endpoint Security\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""

--- a/Targets/ComboFix.tkape
+++ b/Targets/ComboFix.tkape
@@ -1,0 +1,13 @@
+Description: ComboFix Antivirus Data
+Author: Drew Ervin
+Version: 1.0
+Id: 8fb8608e-65ab-4fd1-b7a4-13618caf5ad7
+RecreateDirectories: true
+Targets:
+    -
+        Name: ComboFix
+        Category: Antivirus
+        Path: C:\ComboFix.txt
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/ESET.tkape
+++ b/Targets/ESET.tkape
@@ -1,0 +1,20 @@
+Description: ESET Antivirus Data
+Author: Drew Ervin
+Version: 1.0
+Id: 14ac7bff-2d77-4582-8558-73cf75805aaa
+RecreateDirectories: true
+Targets:
+    -
+        Name: ESET NOD32 AV Logs (XP)
+        Category: Antivirus
+        Path: C:\Documents and Settings\All Users\Application Data\ESET\ESET NOD32 Antivirus\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: ESET NOD32 AV Logs
+        Category: Antivirus
+        Path: C:\ProgramData\ESET\ESET NOD32 Antivirus\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: "Parser available at https://github.com/laciKE/EsetLogParser"

--- a/Targets/FSecure.tkape
+++ b/Targets/FSecure.tkape
@@ -1,0 +1,27 @@
+Description: F-Secure Antivirus Data
+Author: Drew Ervin
+Version: 1.0
+Id: 8bfd6f82-f867-4ce2-89ac-22802ff9a15f
+RecreateDirectories: true
+Targets:
+    -
+        Name: F-Secure Logs
+        Category: Antivirus
+        Path: C:\ProgramData\F-Secure\Log\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: F-Secure User Logs
+        Category: Antivirus
+        Path: C:\Users\*\AppData\Local\F-Secure\Log\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: F-Secure Scheduled Scan Reports
+        Category: Antivirus
+        Path: C:\ProgramData\F-Secure\Antivirus\ScheduledScanReports\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""

--- a/Targets/HitmanPro.tkape
+++ b/Targets/HitmanPro.tkape
@@ -1,0 +1,27 @@
+Description: HitmanPro Antivirus Data
+Author: Drew Ervin
+Version: 1.0
+Id: db98e01b-bd07-4b40-a6ef-e75bdef39bb2
+RecreateDirectories: true
+Targets:
+    -
+        Name: HitmanPro Logs
+        Category: Antivirus
+        Path: C:\ProgramData\HitmanPro\Logs
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: HitmanPro Alert Logs
+        Category: Antivirus
+        Path: C:\ProgramData\HitmanPro.Alert\Logs
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: HitmanPro Database
+        Category: Antivirus
+        Path: C:\ProgramData\HitmanPro.Alert\excalibur.db
+        IsDirectory: false
+        Recursive: false
+        Comment: "SQl Lite DB"

--- a/Targets/Malwarebytes.tkape
+++ b/Targets/Malwarebytes.tkape
@@ -1,0 +1,27 @@
+Description: Malwarebytes Data
+Author: Drew Ervin
+Version: 1.0
+Id: 3509c461-f6ef-499f-87e0-27bb30633259
+RecreateDirectories: true
+Targets:
+    -
+        Name: MalwareBytes Anti-Malware Logs
+        Category: Antivirus
+        Path: C:\ProgramData\Malwarebytes\Malwarebytes Anti-Malware\Logs\mbam-log-*.xml
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: MalwareBytes Anti-Malware Service Logs
+        Category: Antivirus
+        Path: C:\ProgramData\Malwarebytes\MBAMService\logs\mbamservice.log
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -
+        Name: MalwareBytes Anti-Malware Scan Logs
+        Category: Antivirus
+        Path: C:\Users\*\AppData\Roaming\Malwarebytes\Malwarebytes Anti-Malware\Logs
+        IsDirectory: true
+        Recursive: true
+        Comment: ""

--- a/Targets/McAfee.tkape
+++ b/Targets/McAfee.tkape
@@ -1,18 +1,36 @@
 Description: McAfee Log Files
 Author: Sam Smoker
-Version: 1
+Version: 1.1
 Id: d2df019b-35d0-4f7b-8132-7500cbd39901
 RecreateDirectories: True
 Targets:
     -
-        Name: McAfee Logs XP
+        Name: McAfee Desktop Protection Logs XP
         Category: AntiVirus
         Path: C:\Users\All Users\Application Data\McAfee\DesktopProtection
         IsDirectory: true
         Recursive: true
     -
-        Name: McAfee Logs
+        Name: McAfee Desktop Protection Logs
         Category: AntiVirus
         Path: C:\ProgramData\McAfee\DesktopProtection
+        IsDirectory: true
+        Recursive: true
+    -
+        Name: McAfee Endpoint Security Logs
+        Category: AntiVirus
+        Path: C:\ProgramData\McAfee\Endpoint Security\Logs\
+        IsDirectory: true
+        Recursive: true
+    -
+        Name: McAfee Endpoint Security Logs
+        Category: AntiVirus
+        Path: C:\ProgramData\McAfee\Endpoint Security\Logs_Old\
+        IsDirectory: true
+        Recursive: true
+    -
+        Name: McAfee VirusScan Logs
+        Category: AntiVirus
+        Path: C:\ProgramData\Mcafee\VirusScan\
         IsDirectory: true
         Recursive: true

--- a/Targets/RogueKiller.tkape
+++ b/Targets/RogueKiller.tkape
@@ -1,0 +1,13 @@
+Description: RogueKiller Anti-Malware (by Adlice Software)
+Author: Drew Ervin
+Version: 1.0
+Id: 089b2afb-cc29-4565-9c2f-cbf0ba50f10d
+RecreateDirectories: true
+Targets:
+    -
+        Name: RogueKiller Reports
+        Category: Antivirus
+        Path: C:\ProgramData\RogueKiller\logs\AdliceReport_*.json
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/SUPERAntiSpyware.tkape
+++ b/Targets/SUPERAntiSpyware.tkape
@@ -1,0 +1,13 @@
+Description: SUPERAntiSpyware Data
+Author: Drew Ervin
+Version: 1.0
+Id: 0b2c9e30-8d85-43ea-aa26-b20503b8e1da
+RecreateDirectories: true
+Targets:
+    -
+        Name: SUPERAntiSpyware Logs
+        Category: Antivirus
+        Path: C:\Users\*\AppData\Roaming\SUPERAntiSpyware\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""

--- a/Targets/Sophos.tkape
+++ b/Targets/Sophos.tkape
@@ -1,0 +1,27 @@
+Description: Sophos Data
+Author: Drew Ervin
+Version: 1.0
+Id: a50e5204-878e-4b5d-82fb-e6148d976bf7
+RecreateDirectories: true
+Targets:
+    -
+        Name: Sophos Logs (XP)
+        Category: Antivirus
+        Path: C:\Documents and Settings\All Users\Application Data\Sophos\Sophos *\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: "Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
+    -
+        Name: Sophos Logs
+        Category: Antivirus
+        Path: C:\ProgramData\Sophos\Sophos *\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: "Includes Anti-Virus, Client Firewall, Data Control, Device Control, Endpoint Defense, Network Threat Detection, Management Communications System, Patch Control, Tamper Protection"
+    -
+        Name: Sophos Application Events
+        Category: Antivirus
+        Path: ApplicationEvents.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: "Event source: Sophos Anti-Virus"

--- a/Targets/Symantec_AV_Logs.tkape
+++ b/Targets/Symantec_AV_Logs.tkape
@@ -1,20 +1,41 @@
 Description: Symantec AV Logs
 Author: Brian Maloney
-Version: 1
+Version: 1.1
 Id: 5e750ea2-f6dc-4981-88d1-636ce042aa0d
 RecreateDirectories: true
 Targets:
     -
-        Name: Symantec AV Logs
+        Name: Symantec Endpoint Protection Logs (XP)
+        Category: AntiVirus
+        Path: C:\Documents and Settings\All Users\Application Data\Symantec\Symantec Endpoint Protection\Logs\AV
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: Symantec Endpoint Protection Logs
         Category: AntiVirus
         Path: C:\ProgramData\Symantec\Symantec Endpoint Protection\CurrentVersion\Data\Logs
         IsDirectory: true
         Recursive: true
         Comment: ""
     -
-        Name: Symantec AV User Logs
+        Name: Symantec Endpoint Protection User Logs
         Category: AntiVirus
         Path: C:\Users\*\AppData\Local\Symantec\Symantec Endpoint Protection\Logs
         IsDirectory: true
         Recursive: true
         Comment: ""
+    -
+        Name: Symantec Event Log Win7+
+        Category: EventLogs
+        Path: C:\Windows\system32\winevt\logs\Symantec Endpoint Protection Client.evtx
+        IsDirectory: false
+        Recursive: false
+        Comment: "Symantec specific Windows event log"
+    -
+        Name: Symantec Endpoint Protection Manager (SEPM) Application Events
+        Category: EventLogs
+        Path: ApplicationEvents.tkape
+        IsDirectory: false
+        Recursive: false
+        Comment: "Contains SEPM entries, documented here: https://support.symantec.com/us/en/article.tech196455.html"

--- a/Targets/TrendMicro.tkape
+++ b/Targets/TrendMicro.tkape
@@ -1,0 +1,27 @@
+Description: Trend Micro Data
+Author: Drew Ervin
+Version: 1.0
+Id: 73f8ccea-61cf-4993-aa26-e5cad4f8cc8f
+RecreateDirectories: true
+Targets:
+    -    
+        Name: Trend Micro Logs
+        Category: Antivirus
+        Path: C:\ProgramData\Trend Micro\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -    
+        Name: Trend Micro Security Agent Report Logs
+        Category: Antivirus
+        Path: C:\Program Files*\Trend Micro\Security Agent\Report\*.log
+        IsDirectory: false
+        Recursive: false
+        Comment: ""
+    -    
+        Name: Trend Micro Security Agent Connection Logs
+        Category: Antivirus
+        Path: C:\Program Files*\Trend Micro\Security Agent\ConnLog\*.log
+        IsDirectory: false
+        Recursive: false
+        Comment: ""

--- a/Targets/VIPRE.tkape
+++ b/Targets/VIPRE.tkape
@@ -1,0 +1,34 @@
+Description: VIPRE Data
+Author: Drew Ervin
+Version: 1.0
+Id: 8af4ffd8-264e-4c7d-aa28-8cc4f543b01d
+RecreateDirectories: true
+Targets:
+    -
+        Name: VIPRE Business Agent Logs
+        Category: Antivirus
+        Path: C:\ProgramData\VIPRE Business Agent\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: VIPRE Business User Logs (v7+)
+        Category: Antivirus
+        Path: C:\Users\*\AppData\Roaming\VIPRE Business\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: VIPRE Business User Logs (v5-v6)
+        Category: Antivirus
+        Path: C:\Users\*\AppData\Roaming\GFI Software\AntiMalware\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: VIPRE Business User Logs (up to v4)
+        Category: Antivirus
+        Path: C:\Users\*\AppData\Roaming\Sunbelt Software\AntiMalware\Logs\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""

--- a/Targets/WindowsDefender.tkape
+++ b/Targets/WindowsDefender.tkape
@@ -1,0 +1,20 @@
+Description: Windows Defender Data
+Author: Drew Ervin
+Version: 1.0
+Id: 061aa929-292b-4d7f-a4af-a3fe2673a3e5
+RecreateDirectories: true
+Targets:
+    -
+        Name: Windows Defender Logs
+        Category: Antivirus
+        Path: C:\ProgramData\Microsoft\Microsoft AntiMalware\Support\
+        IsDirectory: true
+        Recursive: true
+        Comment: ""
+    -
+        Name: Windows Defender Event Logs
+        Category: EventLogs
+        Path: C:\Windows\System32\winevt\Logs\Microsoft-Windows-WindowsDefender*.evtx
+        IsDirectory: false
+        Recursive: false
+        Comment: ""


### PR DESCRIPTION
Add 13 new antivirus targets:
- Avast.tkape
- Bitdefender.tkape
- ComboFix.tkape
- ESET.tkape
- FSecure.tkape
- HitmanPro.tkape
- Malwarebytes.tkape
- RogueKiller.tkape
- Sophos.tkape
- SUPERAntiSpyware.tkape
- TrendMicro.tkape
- VIPRE.tkape
- WindowsDefender.tkape

Update 2 existing antivirus targets:
- McAfee.tkape
- Symantec_AV_Logs.tkape

Add a composite target to collect all related sub-targets:
- Antivirus.tkape

Verified each has a unique ID and generates no errors when run with --tlist