### PR TITLE
Target for Java WebCache, Chrome Extensions and GroupPolicy

### DIFF
--- a/Targets/Apps/JavaWebCache.tkape
+++ b/Targets/Apps/JavaWebCache.tkape
@@ -1,0 +1,48 @@
+Description: Java WebStart Cache - (IDX Files)
+Author: piesecurity
+Version: 1
+Id: 4dc2e35c-fc20-45f6-89a6-5d729596c522
+RecreateDirectories: true
+Targets:
+    -
+        Name: Java WebStart Cache User Level - Default
+        Category: Communication
+        Path: C:\Users\*\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx
+        IsDirectory: false
+        Recursive: false
+    -
+        Name: Java WebStart Cache User Level - IE Protected Mode
+        Category: Communication
+        Path: C:\Users\*\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx
+        IsDirectory: false
+        Recursive: false
+    -
+        Name: Java WebStart Cache System level
+        Category: Communication
+        Path: C:\Windows\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx
+        IsDirectory: false
+        Recursive: false
+    -
+        Name: Java WebStart Cache System level - IE Protected Mode
+        Category: Communication
+        Path: C:\Windows\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx
+        IsDirectory: false
+        Recursive: false
+    -
+        Name: Java WebStart Cache System level (SysWow64)
+        Category: Communication
+        Path: C:\Windows\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\*.idx
+        IsDirectory: false
+        Recursive: false
+    -
+        Name: Java WebStart Cache System level (SysWow64) - IE Protected Mode
+        Category: Communication
+        Path: C:\Windows\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\*.idx
+        IsDirectory: false
+        Recursive: false
+    -
+        Name: Java WebStart Cache User Level - XP
+        Category: Communications
+        Path: C:\Documents and Settings\*\Application Data\Sun\Java\Deployment\cache\*\*\*.idx
+        IsDirectory: false
+        Recursive: false

--- a/Targets/Browsers/ChromeExtensions.tkape
+++ b/Targets/Browsers/ChromeExtensions.tkape
@@ -1,0 +1,18 @@
+Description: Chrome Extension Files
+Author: piesecurity
+Version: 1
+Id: e748b5e3-e279-4e4d-8083-74293e5b6cde
+RecreateDirectories: true
+Targets:
+    -
+        Name: Chrome Extension Files
+        Category: Communication
+        Path: C:\Users\*\AppData\Local\Google\Chrome\User Data\*\Extensions
+        IsDirectory: true 
+        Recursive: true
+    -
+        Name: Chrome Extension Files XP 
+        Category: Communications
+        Path: c:\Documents and Settings\*\Local Settings\Application Data\Google\Chrome\User Data\*\Extensions
+        IsDirectory: true
+        Recursive: true

--- a/Targets/Windows/GroupPolicy.tkape
+++ b/Targets/Windows/GroupPolicy.tkape
@@ -1,0 +1,25 @@
+Description: Current Group Policy Enforcement
+Author: piesecurity
+Version: 1
+Id: e5595e9c-ebab-41db-a688-fdffe91f6fcb
+RecreateDirectories: true
+Targets:
+    -
+        Name: Local Group Policy INI Files
+        Category: Communication
+        Path: C:\windows\system32\grouppolicy\*.ini
+        IsDirectory: false
+        Recursive: false
+
+    -
+        Name: Local Group Policy Files - Registry Policy Files
+        Category: Communication
+        Path: C:\windows\system32\grouppolicy\*.pol
+        IsDirectory: false
+        Recursive: false
+    -
+        Name: Local Group Policy Files - Startup/Shutdown Scripts
+        Category: Communication
+        Path: C:\windows\system32\grouppolicy\*\Scripts
+        IsDirectory: true 
+        Recursive: true


### PR DESCRIPTION
Since malicious Chrome extensions are so common, what do you think about including the items ChromeExtensions.tkape with the larger Chrome.tkape? For when chrome extensions are removed from the store, this will collect a copy of the javascript for further analysis.