### PR TITLE
Typo causes Defender evtx file to be missed.

### DIFF
--- a/Targets/Antivirus/WindowsDefender.tkape
+++ b/Targets/Antivirus/WindowsDefender.tkape
@@ -14,7 +14,7 @@ Targets:
     -
         Name: Windows Defender Event Logs
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\Logs\Microsoft-Windows-WindowsDefender*.evtx
+        Path: C:\Windows*\System32\winevt\Logs\Microsoft-Windows-Windows Defender*.evtx
         IsDirectory: false
         Recursive: false
         Comment: ""


### PR DESCRIPTION
Space between Windows and Defender