### PR TITLE
Add live response script for local administrators

### DIFF
--- a/Modules/LiveResponse/NetSystemInfo.mkape
+++ b/Modules/LiveResponse/NetSystemInfo.mkape
@@ -1,7 +1,7 @@
 Description: Gathers Basic System Information Using the Net Command
 Category: LiveResponse
-Author: piesecurity
-Version: 1.0
+Author: piesecurity, Andreas Hunkeler (@Karneades)
+Version: 1.1
 Id: be86ac26-4eea-4bcb-b5ae-9686ad0557c4
 ExportFormat: txt 
 Processors:
@@ -11,6 +11,10 @@ Processors:
         ExportFormat: ""
     -
         Executable: NetSystemInfo_LocalGroup.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: NetSystemInfo_Administrators.mkape
         CommandLine: ""
         ExportFormat: ""
     -

--- a/Modules/LiveResponse/NetSystemInfo_Administrators.mkape
+++ b/Modules/LiveResponse/NetSystemInfo_Administrators.mkape
@@ -1,0 +1,14 @@
+Description: Gathers Basic System Information Using the Net Command (members of local administrator group)
+Category: LiveResponse
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 730cf14e-2680-447f-9853-e79ad3aa0e65
+ExportFormat: txt 
+Processors:
+    -
+        Executable: C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine:  -Command "$admin = (Get-LocalGroup -Name 'Admini*').name; net localgroup $admin"
+        ExportFormat: csv
+        ExportFormat: txt
+        ExportFile: NetSystemInfo.txt
+        Append: True


### PR DESCRIPTION
* Add script for **reading the local administrator group independent of the (some) languages**,
  a combination of powershell command to get the name of the admin group and the 
  net localgroup command is used
* **Update NetSystemInfo** module file to include the new script and increase version 
  number in module file