### PR TITLE
Improve autoruns command to include all users

### DIFF
--- a/Modules/LiveResponse/autoruns.mkape
+++ b/Modules/LiveResponse/autoruns.mkape
@@ -1,12 +1,12 @@
 Description: Autoruns reports Explorer shell extensions, toolbars, browser helper objects, Winlogon notifications, auto-start services, and much more.
 Category: LiveResponse
-Author: Andy Furnas, Encoding updates by piesecurity
-Version: 1.1
+Author: Andy Furnas, Encoding updates by piesecurity, Andreas Hunkeler (@Karneades)
+Version: 1.2
 Id: c95e71bd-7abb-48c3-abae-f48b9ff19dec
 BinaryUrl: https://download.sysinternals.com/files/Autoruns.zip
 ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "%kapedirectory%\Modules\bin\autorunsc.exe -a * -s -user * -c -accepteula -nobanner -h | Set-Content -Path %destinationDirectory%\autoruns.csv"
+        CommandLine: -Command "%kapedirectory%\Modules\bin\autorunsc.exe -a * -s -c -accepteula -nobanner -h * | Set-Content -Path %destinationDirectory%\autoruns.csv"
         ExportFormat: csv


### PR DESCRIPTION
Remove "-user" and use the correct command line for including all entries from all profiles and users.