### PR TITLE
Fix module commands for proper handling of spaces in module paths

### DIFF
--- a/Modules/LiveResponse/Get-DoSvcExternalIP.mkape
+++ b/Modules/LiveResponse/Get-DoSvcExternalIP.mkape
@@ -1,14 +1,14 @@
 Description: 'Get-DoSvcExternalIP: extracts public IP addresses from DoSvc EventTraceLogs'
 Category: SystemActivity
 Author: Gabriele Zambelli
-Version: 1
+Version: 1.1
 Id: fc01eeb0-2e2d-4fbe-96b8-02a64933d466
 BinaryUrl: https://raw.githubusercontent.com/forensenellanebbia/powershell-scripts/master/Get-DoSvcExternalIP.ps1
 ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "%kapedirectory%\Modules\bin\Get-DoSvcExternalIP.ps1 %sourceDirectory% -NoIP2Location -OutputPath %destinationDirectory%"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-DoSvcExternalIP.ps1' %sourceDirectory% -NoIP2Location -OutputPath %destinationDirectory%"
         ExportFormat: csv
 #####
 # Get-DoSvcExternalIP extracts public IP addresses of a Windows 10 device from DoSvc EventTraceLogs

--- a/Modules/LiveResponse/Get-NetworkConnection.mkape
+++ b/Modules/LiveResponse/Get-NetworkConnection.mkape
@@ -1,18 +1,18 @@
 Description: 'Get-NetworkConnection including timestamps'
 Category: LiveResponse
 Author: Hadar Yudovich
-Version: 1.0
+Version: 1.1
 Id: 814f00f5-b8c0-4bef-8439-b75bd90c1459
 BinaryUrl: https://raw.githubusercontent.com/IllusiveNetworks-Labs/Get-NetworkConnection/master/Get-NetworkConnection.ps1
 ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1 | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.csv"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.csv"
         ExportFormat: csv
     -
         Executable: C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1 | ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.json"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.json"
         ExportFormat: json
 #####
 # Get-NetworkConnection Returns current TCP and UDP connections, including timestamps!

--- a/Modules/LiveResponse/autoruns.mkape
+++ b/Modules/LiveResponse/autoruns.mkape
@@ -1,7 +1,7 @@
 Description: Autoruns reports Explorer shell extensions, toolbars, browser helper objects, Winlogon notifications, auto-start services, and much more.
 Category: LiveResponse
 Author: Andy Furnas, Encoding updates by piesecurity, Andreas Hunkeler (@Karneades)
-Version: 1.2
+Version: 1.3
 Id: c95e71bd-7abb-48c3-abae-f48b9ff19dec
 BinaryUrl: https://download.sysinternals.com/files/Autoruns.zip
 ExportFormat: csv

--- a/Modules/LiveResponse/autoruns.mkape
+++ b/Modules/LiveResponse/autoruns.mkape
@@ -8,5 +8,5 @@ ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "%kapedirectory%\Modules\bin\autorunsc.exe -a * -s -c -accepteula -nobanner -h * | Set-Content -Path %destinationDirectory%\autoruns.csv"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\autorunsc.exe' -a * -s -c -accepteula -nobanner -h * | Set-Content -Path %destinationDirectory%\autoruns.csv"
         ExportFormat: csv


### PR DESCRIPTION
Fix some module commands where the command fails if the path to the module folder contains spaces. I know, I know, spaces in paths is bad practice but once in a while it happens and in respect to robust evidence collection we should avoid running into such issues :) I run into that while testing the autoruns module and just quickly searched for some other commands missing the required handling of spaces. I guess there are more of these unhandled-space-in-path-issues and would provide additional PRs if I spot them. Additionally, we should already check for that when someone uploads a new file.