### PR TITLE
Create Volatilit_idt.mkape

### DIFF
--- a/Modules/Memory/Volatilit_idt.mkape
+++ b/Modules/Memory/Volatilit_idt.mkape
@@ -1,0 +1,18 @@
+Description: Post-Process memory images with Volatility
+Category: Memory
+Author: Jos Clephas
+Version: 1
+Id: efc76bc6-2c27-492f-be24-fb532bf20d10
+BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
+ExportFormat: greptext
+Processors:
+    -
+        Executable: volatility_2.6_win64_standalone.exe
+        CommandLine: -f %sourceDirectory%\memory.dmp idt --output=greptext --output-file %destinationDirectory%\volatility_idt.txt
+        ExportFormat: greptext
+
+# Place the binary 'volatility_2.6_win64_standalone.exe' into the .\modules\bin folder. And if you want to provide a Volatility profile (such as Win2016x64_14393) or a KDBG, you have to create a file named 'volatilityrc' and place it in the same folder as the Volatility binary. Set the following content in that file:
+#
+#[DEFAULT]
+#PROFILE=Win2016x64_14393
+##KDBG=0x82944c28


### PR DESCRIPTION
I've created a mkape file for almost every Volatility plugin so I can parse memory images very easily - this speeds up my analysis process a lot!