### PR TITLE
Added %SystemRoot%\Minidump folder to memory artifacts

### DIFF
--- a/Targets/Windows/MemoryFiles.tkape
+++ b/Targets/Windows/MemoryFiles.tkape
@@ -1,5 +1,5 @@
 Description: Memory Files
-Author: Ahmed Elshaer
+Author: Ahmed Elshaer, Teo Kia Meng
 Version: 1
 Id: d9e7fc93-7b63-4286-aa05-27ce3437c9c0
 RecreateDirectories: true
@@ -22,3 +22,10 @@ Targets:
         Path: c:\
         FileMask: swapfile.sys
         AlwaysAddToQueue: true
+    -
+        Name: Small Memory Dump directory
+        Category: Memory
+        Path: C:\Windows*\Minidump\     
+        FileMask: '*.dmp'
+        Comment: "https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump"
+        


### PR DESCRIPTION
The %SystemRoot%\Minidump folder contains Small Memory Dumps that are created when Windows crashes, and contain basic data of the system memory at the time of crash

https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump