### PR TITLE
Added VLC Recorded files to VLC Media Player.tkape

### DIFF
--- a/Targets/Apps/VLC Media Player.tkape
+++ b/Targets/Apps/VLC Media Player.tkape
@@ -5,8 +5,14 @@ Id: f7187e39-0410-41cb-b7e0-243d92090c9c
 RecreateDirectories: true
 Targets:
     -
-        Name: VLC Media Recently Opened Files
+        Name: VLC Recently Opened Files
         Category: Apps
         Path: C:\Users\%user%\AppData\Roaming\vlc\
         FileMask: "vlc-qt-interface.ini"
         Comment: "Configuration file for VLC. Holds [RecentsMRL] key which lists recently opened files as well as sometimes retaining timestamps for file opening"
+    -
+        Name: VLC Recorded Files
+        Category: Apps
+        Path: C:\Users\%user%\Videos\
+        FileMask: "vlc-*.avi"
+        Comment: "Recorded files in VLC. Sometimes the Record button may be pressed instead of Play by suspects, which can record them watching content with VLC"


### PR DESCRIPTION
Added recorded files to VLC Media Player.tkape. This can be useful if the record button is mistakenly pressed instead of Play, which can record the actions that the user makes in VLC Player. Tested on local machine in conjunction with --tlist.