### PR TITLE
Initial Windows Subsystem for Linux Kape Targets (Debian + Ubuntu)

### DIFF
--- a/Targets/WSL/Debian.tkape
+++ b/Targets/WSL/Debian.tkape
@@ -87,6 +87,12 @@ Targets:
         Category: Windows Subsystem for Linux
         Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\spool\cron\crontabs
         Recursive: true
+    -
+        Name: Debian WSL Apt Logs
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\log\apt
+        Recursive: true
+        FileMask: "*.log"
         
 # https://blog.1234n6.com/2017/10/further-forensicating-of-windows.html
 # https://medium.com/@tho.le/linux-forensics-some-useful-artifacts-74497dca1ab2

--- a/Targets/WSL/Debian.tkape
+++ b/Targets/WSL/Debian.tkape
@@ -7,62 +7,62 @@ Targets:
     -
         Name: Debian WSL /etc/debian_version
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "debian_version"
     -
         Name: Debian WSL /etc/fstab
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "fstab"
     -
         Name: Debian WSL /etc/os-release
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "os-release"
     -
         Name: Debian WSL /etc/passwd
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "passwd"
     -
         Name: Debian WSL /etc/group
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "group"
     -
         Name: Debian WSL /etc/shadow
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "shadow"
     -
         Name: Debian WSL /etc/timezone
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "timezone"
     -
         Name: Debian WSL /etc/hostname
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "hostname"
     -
         Name: Debian WSL /etc/hosts
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "hosts"
     -
         Name: Debian WSL /etc/crontab
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "crontab"
     -
         Name: Debian WSL /etc/bash.bashrc
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "bash.bashrc"
     -
         Name: Debian WSL /etc/profile
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc\
         FileMask: "profile"
     -
         Name: Debian WSL .bash_history
@@ -85,12 +85,12 @@ Targets:
     -
         Name: Debian WSL User Crontabs
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\spool\cron\crontabs
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\spool\cron\crontabs\
         Recursive: true
     -
         Name: Debian WSL Apt Logs
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\log\apt
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\log\apt\
         Recursive: true
         FileMask: "*.log"
         

--- a/Targets/WSL/Debian.tkape
+++ b/Targets/WSL/Debian.tkape
@@ -1,0 +1,87 @@
+Description: Debian on Windows Subsystem for Linux
+Author: Matt Dawson
+Version: 1.0
+Id: 3629bafb-16b5-41de-988f-6961c6d3b6e1
+RecreateDirectories: true
+Targets:
+    -
+        Name: Debian WSL /etc/debian_version
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "debian_version"
+    -
+        Name: Debian WSL /etc/os-release
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "os-release"
+    -
+        Name: Debian WSL /etc/passwd
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "passwd"
+    -
+        Name: Debian WSL /etc/group
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "group"
+    -
+        Name: Debian WSL /etc/shadow
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "shadow"
+    -
+        Name: Debian WSL /etc/timezone
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "timezone"
+    -
+        Name: Debian WSL /etc/hostname
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "hostname"
+    -
+        Name: Debian WSL /etc/hosts
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "hosts"
+    -
+        Name: Debian WSL /etc/crontab
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "crontab"
+    -
+        Name: Debian WSL /etc/bash.bashrc
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "bash.bashrc"
+    -
+        Name: Debian WSL /etc/profile
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "profile"
+    -
+        Name: Debian WSL .bash_history
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\
+        Recursive: true
+        FileMask: ".bash_history"
+    -
+        Name: Debian WSL .bashrc
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\
+        Recursive: true
+        FileMask: ".bashrc"
+    -
+        Name: Debian WSL .profile
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\
+        Recursive: true
+        FileMask: ".profile"
+    -
+        Name: Debian WSL User Crontabs
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\var\spool\cron\crontabs
+        Recursive: true
+        
+# https://blog.1234n6.com/2017/10/further-forensicating-of-windows.html
+# https://medium.com/@tho.le/linux-forensics-some-useful-artifacts-74497dca1ab2

--- a/Targets/WSL/Debian.tkape
+++ b/Targets/WSL/Debian.tkape
@@ -10,6 +10,11 @@ Targets:
         Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
         FileMask: "debian_version"
     -
+        Name: Debian WSL /etc/fstab
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc
+        FileMask: "fstab"
+    -
         Name: Debian WSL /etc/os-release
         Category: Windows Subsystem for Linux
         Path: C:\Users\%user%\AppData\Local\Packages\TheDebianProject.DebianGNULinux_*\LocalState\rootfs\etc

--- a/Targets/WSL/Ubuntu.tkape
+++ b/Targets/WSL/Ubuntu.tkape
@@ -1,0 +1,90 @@
+Description: Ubuntu on Windows Subsystem for Linux
+Author: Matt Dawson
+Version: 1.0
+Id: 08b27869-b454-403a-84af-2aa1f2f69a37
+RecreateDirectories: true
+Targets:
+    -
+        Name: Ubuntu WSL /etc/os-release
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "os-release"
+    -
+        Name: Ubuntu WSL /etc/fstab
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "fstab"
+    -
+        Name: Ubuntu WSL /etc/passwd
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "passwd"
+    -
+        Name: Ubuntu WSL /etc/group
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "group"
+    -
+        Name: Ubuntu WSL /etc/shadow
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "shadow"
+    -
+        Name: Ubuntu WSL /etc/timezone
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "timezone"
+    -
+        Name: Ubuntu WSL /etc/hostname
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "hostname"
+    -
+        Name: Ubuntu WSL /etc/hosts
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "hosts"
+    -
+        Name: Ubuntu WSL /etc/crontab
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "crontab"
+    -
+        Name: Ubuntu WSL /etc/bash.bashrc
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "bash.bashrc"
+    -
+        Name: Ubuntu WSL /etc/profile
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        FileMask: "profile"
+    -
+        Name: Ubuntu WSL .bash_history
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\
+        Recursive: true
+        FileMask: ".bash_history"
+    -
+        Name: Ubuntu WSL .bashrc
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\
+        Recursive: true
+        FileMask: ".bashrc"
+    -
+        Name: Ubuntu WSL .profile
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\
+        Recursive: true
+        FileMask: ".profile"
+    -
+        Name: Ubuntu WSL User Crontabs
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\spool\cron\crontabs
+        Recursive: true
+    -
+        Name: Ubuntu WSL Apt Logs
+        Category: Windows Subsystem for Linux
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\log\apt
+        Recursive: true
+        FileMask: "*.log"

--- a/Targets/WSL/Ubuntu.tkape
+++ b/Targets/WSL/Ubuntu.tkape
@@ -7,57 +7,57 @@ Targets:
     -
         Name: Ubuntu WSL /etc/os-release
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "os-release"
     -
         Name: Ubuntu WSL /etc/fstab
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "fstab"
     -
         Name: Ubuntu WSL /etc/passwd
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "passwd"
     -
         Name: Ubuntu WSL /etc/group
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "group"
     -
         Name: Ubuntu WSL /etc/shadow
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "shadow"
     -
         Name: Ubuntu WSL /etc/timezone
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "timezone"
     -
         Name: Ubuntu WSL /etc/hostname
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "hostname"
     -
         Name: Ubuntu WSL /etc/hosts
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "hosts"
     -
         Name: Ubuntu WSL /etc/crontab
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "crontab"
     -
         Name: Ubuntu WSL /etc/bash.bashrc
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "bash.bashrc"
     -
         Name: Ubuntu WSL /etc/profile
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\etc\
         FileMask: "profile"
     -
         Name: Ubuntu WSL .bash_history
@@ -80,11 +80,11 @@ Targets:
     -
         Name: Ubuntu WSL User Crontabs
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\spool\cron\crontabs
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\spool\cron\crontabs\
         Recursive: true
     -
         Name: Ubuntu WSL Apt Logs
         Category: Windows Subsystem for Linux
-        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\log\apt
+        Path: C:\Users\%user%\AppData\Local\Packages\CanonicalGroupLimited.Ubuntu*\LocalState\rootfs\var\log\apt\
         Recursive: true
         FileMask: "*.log"


### PR DESCRIPTION
I've done two initial WSL targets - Debian and Ubuntu (Normal, 18.04 LTS and 20.04 LTS) as these are the "big" Distros that are more commonly in use.
I'm not overly familiar with key Linux artifacts (obvious things like .bash_history, /etc/passwd, etc. are included in collection) and it does appear that some artifacts are missing on WSL (/var/log/auth.log is one example), so I'm aware I might have missed some artifacts which could be more obvious for others.
I'll keep working through the different WSL versions available on the Microsoft Store to produce the same base-level targets for all of them. As a result of the large number of WSL distros available, I've put the new targets in their own WSL folder as there will be several more which I plan to add soon (Kali, openSUSE, SLSE etc.).
As usual, tested on my local machine and with `--tlist WSL`