### PR TITLE
Added LevelDBDumper.mkape

### DIFF
--- a/Modules/Misc/LevelDBDumper.mkape
+++ b/Modules/Misc/LevelDBDumper.mkape
@@ -1,0 +1,13 @@
+Description: Dumps LevelDB Key/Value databases
+Category: Databases
+Author: Matt Dawson
+Version: 1.0
+Id: 3a88b531-705b-487d-933c-75ce0921a656
+BinaryUrl: https://github.com/mdawsonuk/LevelDBDumper/releases
+ExportFormat: csv
+Processors:
+    -
+        Executable: LevelDBDumper.exe
+        CommandLine: "-d %sourceDirectory% --csv %destinationDirectory% -q"
+        ExportFormat: csv
+        ExportFile: "LevelDBDumperOutput.log"


### PR DESCRIPTION
Added a module which uses my LevelDBDumper tool to parse LevelDB databases (used by Discord, WhatsApp, Electron & Chromium apps etc.) to a CSV file (Key,Value) for easy analysis of their values. Tested extensively on local machine with --mlist.