### PR TITLE
Virtualbox Targets

### DIFF
--- a/Targets/Apps/Virtualbox.tkape
+++ b/Targets/Apps/Virtualbox.tkape
@@ -1,0 +1,18 @@
+Description: Runs all Virtualbox modules to collect Virtualbox VM config files, logs and Virtual Hard Disks
+Author: Matt Dawson
+Version: 1.0
+Id: b6ce74ad-11a1-4e3c-851e-f8772749894b
+RecreateDirectories: true
+Targets:
+    -
+        Name: Virtualbox Logs
+        Category: Apps
+        Path: VirtualboxLogs.tkape
+    -
+        Name: Virtualbox Configs
+        Category: Apps
+        Path: VirtualboxConfig.tkape
+    -
+        Name: Virtual Hard Drives
+        Category: Apps
+        Path: ..\Misc\VirtualDisks.tkape

--- a/Targets/Apps/VirtualboxConfig.tkape
+++ b/Targets/Apps/VirtualboxConfig.tkape
@@ -1,0 +1,20 @@
+Description: Collects Virtualbox configuration files
+Author: Matt Dawson
+Version: 1.0
+Id: 0983f8c9-721b-4dd5-b4d2-f16ee289b1c3
+RecreateDirectories: true
+Targets:
+    -
+        Name: Virtualbox VM configs
+        Category: Apps
+        Path: C:\
+        Recursive: true
+        FileMask: "*.vbox"
+        Comment: "Locates all .vbox VM configuration files on disk"
+    -
+        Name: Virtualbox VM backup configs
+        Category: Apps
+        Path: C:\
+        Recursive: true
+        FileMask: "*.vbox-prev"
+        Comment: "Locates all backup .vbox VM configuration files on disk"

--- a/Targets/Apps/VirtualboxLogs.tkape
+++ b/Targets/Apps/VirtualboxLogs.tkape
@@ -1,0 +1,27 @@
+Description: Collects Virtualbox log files
+Author: Matt Dawson
+Version: 1.0
+Id: 3d5398fc-5774-4329-a268-29ed1a6d4d9e
+RecreateDirectories: true
+Targets:
+    -
+        Name: Virtualbox Logs
+        Category: Apps
+        Path: C:\
+        Recursive: true
+        FileMask: "VBox.log"
+        Comment: "Locates all VBox.log files on disk"
+    -
+        Name: Virtualbox Backup Logs
+        Category: Apps
+        Path: C:\
+        Recursive: true
+        FileMask: "VBox.log.*"
+        Comment: "Locates all backup VBox.log files on disk - these can show historic VM usage"
+    -
+        Name: Virtualbox Hardening Logs
+        Category: Apps
+        Path: C:\
+        Recursive: true
+        FileMask: "VBoxHardening.log"
+        Comment: "Locates all VBoxHardening.log files on disk"


### PR DESCRIPTION
## Description

Added Virtualbox Config target, Virtualbox Logs target and a target which runs both of the previously mentioned modules, as well as the VirtualDisks module

## Checklist:

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
