### PR TITLE
Added Evernote target

### DIFF
--- a/Targets/Apps/Evernote.tkape
+++ b/Targets/Apps/Evernote.tkape
@@ -1,0 +1,27 @@
+Description: Evernote
+Author: Matt Dawson
+Version: 1.0
+Id: acea0975-6610-4813-8a27-8e78186c87d5
+RecreateDirectories: true
+Targets:
+   -
+        Name: Evernote Accounts
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\Evernote\Evernote\Databases\
+        Recursive: true
+        FileMask: ".accounts"
+        Comment: "Holds username and email of accounts"
+   -
+        Name: Evernote Notebooks
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\Evernote\Evernote\Databases\
+        Recursive: true
+        FileMask: "*.exb"
+        Comment: "SQLite Database of the notes"
+   -
+        Name: Evernote Notebook Snippets
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\Evernote\Evernote\Databases\
+        Recursive: true
+        FileMask: "*.exb.snippets"
+        Comment: "Note 'Snippets'"


### PR DESCRIPTION
## Description

Added target to get Evernote accounts, notes database and "snippets"

## Checklist:

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
