### PR TITLE
New Targets, Update README, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For thorough documentation, go [HERE](https://ericzimmerman.github.io/KapeDocs/#
 
 It is also possible to attend KAPE training from Kroll instructors. Details can be found [HERE](training.md)!!
 
-### NOTE: We have clarified KAPE usage permissions for commerial applications. See details [here](https://ericzimmerman.github.io/KapeDocs/#!Pages\50-Frequently-asked-questions.md)
+### NOTE: We have clarified KAPE usage permissions for commercial applications. See details [here](https://ericzimmerman.github.io/KapeDocs/#!Pages\50-Frequently-asked-questions.md).
 
 
 ## TL;DR; for target and module creation is stated below:

--- a/Targets/Apps/VMwareInventory.tkape
+++ b/Targets/Apps/VMwareInventory.tkape
@@ -1,4 +1,4 @@
-Description: VMware
+Description: VMware - Virtual Machine Inventory
 Author: Andrew Rathbun
 Version: 1.0
 Id: 92d4917d-54a3-48a1-873b-ea2ddad58b84

--- a/Targets/Apps/VMwareInventory.tkape
+++ b/Targets/Apps/VMwareInventory.tkape
@@ -14,4 +14,5 @@ Targets:
 # VMware Workstation Pro stores a file named inventory.vmls which will provide file paths to Virtual Machines located on the user's system.
 # Important evidence could be located within these Virtual Machines so this is great information to know. 
 # Preferences.ini will provide other file paths relating to the existing Virtual Machines on the user's system.
+# Inventory.vmls can be viewed in any text editor and provides similar information to Preferences.ini. 
 ######

--- a/Targets/Apps/VMwareMemory.tkape
+++ b/Targets/Apps/VMwareMemory.tkape
@@ -1,0 +1,27 @@
+Description: VMware - Virtual Machine Memory
+Author: Andrew Rathbun
+Version: 1
+Id: 45945262-2e36-47c7-a36f-3cf4124dbe63
+RecreateDirectories: true
+Targets:
+    -
+        Name: VMware (Fusion/Workstation/Server/Player)
+        Category: Memory
+        Path: C:\
+        FileMask: '*.vmem'
+        Recursive: true
+        Comment: "Captures all raw memory from VMware virtual machines."
+    -
+        Name: VMware (Fusion/Workstation/Server/Player)
+        Category: Memory
+        Path: C:\
+        FileMask: '*.vmss'
+        Recursive: true
+        Comment: "Captures all memory images from VMware virtual machines."
+    -
+        Name: VMware (Fusion/Workstation/Server/Player)
+        Category: Memory
+        Path: C:\
+        FileMask: '*.vmsn'
+        Recursive: true
+        Comment: "Captures all memory images from VMware virtual machines."

--- a/Targets/Apps/VirtualBoxMemory.tkape
+++ b/Targets/Apps/VirtualBoxMemory.tkape
@@ -1,4 +1,4 @@
-Description: Virtual Machines - Memory
+Description: VirtualBox - Memory
 Author: Andrew Rathbun
 Version: 1
 Id: 4af61e3f-7fa7-4c59-a6d7-a495582fbb56

--- a/Targets/Apps/VirtualBoxMemory.tkape
+++ b/Targets/Apps/VirtualBoxMemory.tkape
@@ -1,0 +1,13 @@
+Description: Virtual Machines - Memory
+Author: Andrew Rathbun
+Version: 1
+Id: 4af61e3f-7fa7-4c59-a6d7-a495582fbb56
+RecreateDirectories: true
+Targets:
+    -
+        Name: VirtualBox
+        Category: Memory
+        Path: C:\
+        FileMask: '*.sav'
+        Recursive: true
+        Comment: "Captures all partial memory images from VirtualBox."


### PR DESCRIPTION
## Description

Added VMware/VirtualBox Memory targets. Correct spelling error in README.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have generated a unique GUID for my target(s)/module(s)
- [X] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
