### PR TITLE
Added JDownloader 2.0 Target

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
   <h3 align="center">KAPE Files</h3>
 	
   <p align="center">
-    <a href="LICENSE" alt="License">
-		<img src="https://img.shields.io/github/license/EricZimmerman/KapeFiles?style=flat-square" /></a>
-	<a href="https://github.com/EricZimmerman/KapeFiles/issues" alt="Issues">
-		<img src="https://img.shields.io/github/issues/EricZimmerman/KapeFiles?style=flat-square" /></a>
+  <a href="LICENSE" alt="License">
+    <img src="https://img.shields.io/github/license/EricZimmerman/KapeFiles?style=flat-square" /></a>
+  <a href="https://github.com/EricZimmerman/KapeFiles/issues" alt="Issues">
+    <img src="https://img.shields.io/github/issues/EricZimmerman/KapeFiles?style=flat-square" /></a>
   <a href="https://github.com/EricZimmerman/KapeFiles/graphs/contributors" alt="Contributors">
     <img src="https://img.shields.io/github/contributors/EricZimmerman/KapeFiles?style=flat-square" /></a>
-  <a href="https://github.com/EricZimmerman/KapeFiles/" alt="Closed PRs">
+  <a href="https://github.com/EricZimmerman/KapeFiles/pulls?q=is%3Apr+is%3Aclosed" alt="Closed PRs">
     <img src="https://img.shields.io/github/issues-pr-closed/EricZimmerman/KapeFiles?style=flat-square" /></a>
-  <a href="https://github.com/EricZimmerman/KapeFiles/" alt="Forks">
+  <a href="https://github.com/EricZimmerman/KapeFiles/network/members/" alt="Forks">
 		<img src="https://img.shields.io/github/forks/EricZimmerman/KapeFiles?style=flat-square" /></a>
-  <a href="https://github.com/EricZimmerman/KapeFiles/" alt="Stars">
+  <a href="https://github.com/EricZimmerman/KapeFiles/stargazers/" alt="Stars">
 		<img src="https://img.shields.io/github/stars/EricZimmerman/KapeFiles?style=flat-square" /></a>
   
   </p>

--- a/Targets/P2P/JDownloader2.tkape
+++ b/Targets/P2P/JDownloader2.tkape
@@ -1,0 +1,41 @@
+Description: JDownloader 2
+Author: Matt Dawson
+Version: 1.0
+Id: 41b218bd-c886-442d-b3a6-7a18a1cd4091
+RecreateDirectories: true
+Targets:
+    -
+        Name: JDownloader 2.0 Download Lists
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\JDownloader 2.0\cfg
+        Recursive: true
+        FileMask: "downloadList*.zip"
+        Comment: "Zip folder which contains several files (00,00_00 and extraInfo) which list the download folder, the time it was created, the name of the download, origin URL, referral URL and more"
+    -
+        Name: JDownloader 2.0 Link Collector
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\JDownloader 2.0\cfg
+        Recursive: true
+        FileMask: "linkcollector*.zip"
+        Comment: "Zip folder which contains several files (0X,0X_00 and extraInfo) which list the websites crawled for links, the referral URLs, timestamps and more"
+    -
+        Name: JDownloader 2.0 General Settings
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\JDownloader 2.0\cfg
+        Recursive: true
+        FileMask: "org.jdownloader.settings.GeneralSettings.json"
+        Comment: "General user config for JDownloader 2.0. Holds default download folder."
+    -
+        Name: JDownloader 2.0 Link Grabber Settings
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\JDownloader 2.0\cfg
+        Recursive: true
+        FileMask: "org.jdownloader.gui.views.linkgrabber.addlinksdialog.LinkgrabberSettings.json"
+        Comment: "Linkgrabber Settings for JDownloader 2.0. Holds latest download destination folder."
+    -
+        Name: JDownloader 2.0 Proxy Settings
+        Category: App
+        Path: C:\Users\%user%\AppData\Local\JDownloader 2.0\cfg
+        Recursive: true
+        FileMask: "org.jdownloader.settings.InternetConnectionSettings.customproxylist.json"
+        Comment: "Proxy configuration for JDownloader 2.0"


### PR DESCRIPTION
## Description

Added target for JDownloader 2.0. Also fixed the README having some links which didn't point to relevant Github pages.

## Checklist:

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
