### PR TITLE
Added VMware.tkape

### DIFF
--- a/Targets/Apps/VMware.tkape
+++ b/Targets/Apps/VMware.tkape
@@ -1,0 +1,18 @@
+Description: Runs all VMware modules to collect VMware VM config files, logs and Virtual Hard Disks
+Author: Matt Dawson
+Version: 1.0
+Id: 386c40b5-8fc4-495e-b34e-47508e6c3f73
+RecreateDirectories: true
+Targets:
+    -
+        Name: VMware Inventory
+        Category: Apps
+        Path: VMwareInventory.tkape
+    -
+        Name: VMware Memory
+        Category: Apps
+        Path: VMwareMemory.tkape
+    -
+        Name: Virtual Hard Drives
+        Category: Apps
+        Path: ..\Misc\VirtualDisks.tkape


### PR DESCRIPTION
## Description

Created VMware.tkape to run all VMware modules (same principle as VirtualBox.tkape)

## Checklist:

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
