### PR TITLE
Add FreeCommander.tkape and DoubleCommander.tkape

### DIFF
--- a/Targets/Apps/DoubleCommander.tkape
+++ b/Targets/Apps/DoubleCommander.tkape
@@ -1,0 +1,57 @@
+Description: Double Commander
+Author: Andrew Rathbun
+Version: 1.0
+Id: 80c608ac-0be4-4bbf-a09e-97d2f6cb90f4
+RecreateDirectories: true
+Targets:
+    -
+        Name: Double Commander - history.xml
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\doublecmd\
+        FileMask: 'history.xml'
+        Comment: "Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from bottom to top."
+    -
+        Name: Double Commander - doublecmd.xml
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\doublecmd\
+        FileMask: 'doublecmd.xml'
+        Comment: "Locates an .xml file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom."
+
+######
+# Double Commander is a freeware Windows File Explorer replacement similar in function to Total Commander, which is commonly used by threat actors during IR incidents.
+# If you open up the history.xml file path in a text editor, depending on how big the file is, all your artifacts equivalent to Shellbags should be located under a <Navigation> string with each "Shellbag" preprended by <Item>. 
+# It should be noted that these are sorted in descending order, meaning the top item is the most recent folder navigated to by the user.
+# It should be noted that history.xml only updates when Double Commander is closed. 
+# For instance, I explored the following paths in this order from bottom to top:
+#      <Item>C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\</Item>
+#      <Item>C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\Settings\</Item>
+#      <Item>C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\Layouts\</Item>
+#      <Item>C:\Users\%user%\Desktop\EZ Tools\</Item>
+#      <Item>C:\Users\%user%\Desktop\EZ Tools\SDBExplorer\</Item>
+#      <Item>C:\Users\%user%\Desktop\EZ Tools\EZViewer\</Item>
+#      <Item>C:\Users\%user%\Desktop\</Item>
+#      <Item>C:\Users\%user%\</Item>
+#      <Item>C:\Users\</Item>
+#      <Item>C:\</Item>
+#      <Item>C:\Program Files\</Item>
+# Doublecmd.xml has a lot more information overall than history.xml, but it does have similar Shellbags-equivalent artifacts that are sorted in descending order. 
+# If you open up the doublecmd.xml file path in a text editor, search for the following string: <Path Filename= and you will start seeing these artifacts. 
+# For instance, besides the top two lines, I explored the following paths in this order from top to bottom:
+#	<Path Filename="bz2.dll">C:\Program Files\Double Commander\</Path>
+#	<Path Filename="Double Commander">C:\Program Files\</Path>
+#       <Path Filename="Users">C:\</Path>
+#       <Path Filename="%user%">C:\Users\</Path>
+#       <Path Filename="Desktop">C:\Users\%user%\</Path>
+#       <Path Filename="EZ Tools">C:\Users\%user%\Desktop\</Path>
+#       <Path Filename="EZViewer">C:\Users\%user%\Desktop\EZ Tools\</Path>
+#       <Path Filename="..">C:\Users\%user%\Desktop\EZ Tools\EZViewer\</Path>
+#       <Path Filename="SDBExplorer">C:\Users\%user%\Desktop\EZ Tools\</Path>
+#       <Path Filename="..">C:\Users\%user%\Desktop\EZ Tools\SDBExplorer\</Path>
+#       <Path Filename="TimelineExplorer">C:\Users\%user%\Desktop\EZ Tools\</Path>
+#       <Path Filename="Layouts">C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\</Path>
+#       <Path Filename="..">C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\Layouts\</Path>
+#       <Path Filename="Settings">C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\</Path>
+#       <Path Filename="..">C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\Settings\</Path>
+#       <Path Filename="Settings">C:\Users\%user%\Desktop\EZ Tools\TimelineExplorer\</Path>
+# These artifacts can be very useful when your threat actor isn't using File Explorer. 
+######

--- a/Targets/Apps/FreeCommander.tkape
+++ b/Targets/Apps/FreeCommander.tkape
@@ -34,6 +34,7 @@ Targets:
         Path: C:\Users\%user%\AppData\Local\FreeCommanderXE\Settings\Bkp_Settings*\
         Recursive: True
         Comment: "Locates an exact copy of the above files which will have a timestamped folder name, i.e. Bkp_Settings-YYYY-MM-DD HH-MM-SS."
+        
 ######
 # Free Commander is a freeware Windows File Explorer replacement similar in function to Total Commander, which is commonly used by threat actors during IR incidents.
 # FreeCommander.ini contains some interesting artifacts including but not limited to: Path= (starting path when opening a browser window, sorted by Left and Right), PathLastUsed= (path last opened upon program exit), and [MainPanel] (will contain the last opened paths for both Left and Right directory browsers).

--- a/Targets/Apps/FreeCommander.tkape
+++ b/Targets/Apps/FreeCommander.tkape
@@ -1,0 +1,44 @@
+Description: Free Commander
+Author: Andrew Rathbun
+Version: 1.0
+Id: 418ce15d-2400-4deb-b7bf-546a99095804
+RecreateDirectories: true
+Targets:
+    -
+        Name: Free Commander - FreeCommander.ini
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\FreeCommanderXE\Settings\
+        FileMask: 'FreeCommander.ini'
+        Comment: "Locates an .ini file that contains Shellbags-equivalent artifacts."
+    -
+        Name: Free Commander - FreeCommander.ftp.ini
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\FreeCommanderXE\Settings\
+        FileMask: 'FreeCommander.ftp.ini'
+        Comment: "Locates an .ini file that contains the file path to the FTP log for Free Commander."
+    -
+        Name: Free Commander - FreeCommander.hist.ini
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\FreeCommanderXE\Settings\
+        FileMask: 'FreeCommander.hist.ini'
+        Comment: "Locates an .ini file that contains Shellbags-equivalent artifacts that are sorted in temporal order from top to bottom for both left and right directory browsers."
+    -
+        Name: Free Commander - FreeCommander.fav.xml
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\FreeCommanderXE\Settings\
+        FileMask: 'FreeCommander.fav.xml'
+        Comment: "Locates an .xml file that contains favorited files/folder by the user."
+    -
+        Name: Free Commander - Backup Settings
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\FreeCommanderXE\Settings\Bkp_Settings*\
+        Recursive: True
+        Comment: "Locates an exact copy of the above files which will have a timestamped folder name, i.e. Bkp_Settings-YYYY-MM-DD HH-MM-SS."
+######
+# Free Commander is a freeware Windows File Explorer replacement similar in function to Total Commander, which is commonly used by threat actors during IR incidents.
+# FreeCommander.ini contains some interesting artifacts including but not limited to: Path= (starting path when opening a browser window, sorted by Left and Right), PathLastUsed= (path last opened upon program exit), and [MainPanel] (will contain the last opened paths for both Left and Right directory browsers).
+# FreeCommander.ftp.ini contains a file path to the FTP log. 
+# FreeCommander.hist.ini updates upon program exit and only records the last 30 folders browsed by the user. History0 is the most recent folder browsed whereas History29 is the least recent. Log continues to roll over after 30 entries. 
+# In FreeCommander.fav.xml, the string <folder_item will be the beginning of a new entry which will include the file path of the file/folder that the user favorited.
+# Note: for the Backup Settings target above, you may only see a deduplicated version of that folder, I.E. there may only be one or two files. This is because the backup files are exactly the same as the current set of .ini and .xml files. If the user has a long history of using the program, there should be many more files as a result. 
+######


### PR DESCRIPTION
## Description

Add FreeCommander.tkape and DoubleCommander.tkape.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have generated a unique GUID for my target(s)/module(s)
- [X] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
