### PR TITLE
Update RemoteAdmin.tkape

### DIFF
--- a/Targets/Misc/RemoteAdmin.tkape
+++ b/Targets/Misc/RemoteAdmin.tkape
@@ -34,7 +34,7 @@ Targets:
         Category: ApplicationData
         Path: RDPCache.tkape
         Comment: "Contains data cached during recent RDP sessions"
--
+    -
         Name: RDP Logs
         Category: EventLogs
         Path: RDPLogs.tkape


### PR DESCRIPTION
## Description

No clue how that happened. 

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have generated a unique GUID for my target(s)/module(s)
- [X] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
