### PR TITLE
Update KapeTriage.tkape

### DIFF
--- a/Targets/Compound/KapeTriage.tkape
+++ b/Targets/Compound/KapeTriage.tkape
@@ -41,6 +41,6 @@ Targets:
         Category: Targets
         Path: RemoteAdmin.tkape
     -
-        Name: AntiVirus
+        Name: Antivirus
         Category: Targets
-        Path: Antivirus\*
+        Path: Antivirus.tkape


### PR DESCRIPTION
## Description

Point to Antivirus compound Target instead of Antivirus folder for consistency.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
