### PR TITLE
Add Macrium Reflect target and update Version to create a uniform standard

### DIFF
--- a/Modules/!Disabled/ApplicationEvents.mkape
+++ b/Modules/!Disabled/ApplicationEvents.mkape
@@ -1,7 +1,7 @@
 Description: Parses Application event log using TZWorks evtwalk64
 Category: ProgramExecution
 Author: Justin Price
-Version: 1
+Version: 1.0
 Id: 64cda4d2-8fa0-4948-a994-6b60bc1a50b7
 BinaryUrl: https://tzworks.net/download_links.php
 ExportFormat: csv

--- a/Modules/!Disabled/Plaso.mkape
+++ b/Modules/!Disabled/Plaso.mkape
@@ -1,7 +1,7 @@
 Description: plaso end to end test
 Category: Timeline
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: b9f74cd7-b80d-4a5c-8381-6e260ffffdf5
 BinaryUrl: https://github.com/log2timeline/plaso/releases
 ExportFormat: csv

--- a/Modules/!Disabled/Volatility_AllDisabled.mkape
+++ b/Modules/!Disabled/Volatility_AllDisabled.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility. The mkape files in this file are disabled by-default because the Volatility plugins have a high runtime and most of them are commonly not used for triage.
 Category: Modules
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: aa982fb9-dc79-4e42-85d8-34079ef9271c
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_apihooks.mkape
+++ b/Modules/!Disabled/Volatility_apihooks.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 36132289-5263-42a4-b72f-08857dd60d6b
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_dlldump.mkape
+++ b/Modules/!Disabled/Volatility_dlldump.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: f611f68a-1248-42ca-b3d4-8e88469ce586
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_dumpfiles.mkape
+++ b/Modules/!Disabled/Volatility_dumpfiles.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: e178efa8-0069-456c-af17-732f4167d659
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_filescan.mkape
+++ b/Modules/!Disabled/Volatility_filescan.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: d38d69c6-4084-474d-99c0-26f2b9786179
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_handles.mkape
+++ b/Modules/!Disabled/Volatility_handles.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 02fabdaf-a3ea-4fae-ba4c-fea21fe6ed14
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_malfind_dump.mkape
+++ b/Modules/!Disabled/Volatility_malfind_dump.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: c59b9b45-1bf5-4fc9-a1fd-c90df6c75102
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_memdump.mkape
+++ b/Modules/!Disabled/Volatility_memdump.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: e734c060-d736-4d1a-a411-93773a87b6c3
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_mftparser.mkape
+++ b/Modules/!Disabled/Volatility_mftparser.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 477a6087-89c8-40c2-8222-40b77468abb2
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_moddump.mkape
+++ b/Modules/!Disabled/Volatility_moddump.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: e2959a50-4d5c-480c-b76a-0dc72a8dfd9f
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_procdump.mkape
+++ b/Modules/!Disabled/Volatility_procdump.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 8123f60c-5f61-486b-ad2c-1ea944037594
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_shellbags.mkape
+++ b/Modules/!Disabled/Volatility_shellbags.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 20ab011d-7142-4132-b153-15f745b1bebb
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/!Disabled/Volatility_timeliner.mkape
+++ b/Modules/!Disabled/Volatility_timeliner.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: c95e3951-d518-4de8-896c-4755707d0f55
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/BrowsingHistory/BrowsingHistoryView.mkape
+++ b/Modules/BrowsingHistory/BrowsingHistoryView.mkape
@@ -1,7 +1,7 @@
 Description: 'Browsing History View - Nirsoft'
 Category: BrowsingHistory
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 53d5bea2-b3d3-4a60-8844-be898390adc1
 BinaryUrl: https://www.nirsoft.net/utils/browsinghistoryview-x64.zip
 ExportFormat: csv

--- a/Modules/EventLogs/ApplicationFullEventLogView.mkape
+++ b/Modules/EventLogs/ApplicationFullEventLogView.mkape
@@ -1,7 +1,7 @@
 Description: Parses Application event log using Nirsoft FullEventLogView.exe
 Category: EventLogs
 Author: Barrie Hill
-Version: 1
+Version: 1.0
 Id: 505019ce-2fae-4a87-bcf5-cc663c60b030
 BinaryUrl: https://www.nirsoft.net/utils/fulleventlogview-x64.zip
 ExportFormat: csv

--- a/Modules/EventLogs/Detailed-Network-Share-Access.mkape
+++ b/Modules/EventLogs/Detailed-Network-Share-Access.mkape
@@ -1,7 +1,7 @@
 Description: LogParser Security event 5145
 Category: RemoteAccess
 Author: Brian Maloney/@sbousseaden
-Version: 1
+Version: 1.0
 Id: 2d3f0292-d302-4d4a-b292-f8fbd58b8498
 BinaryUrl: https://www.microsoft.com/en-us/download/confirmation.aspx?id=24659
 ExportFormat: csv

--- a/Modules/EventLogs/EvtxECmd-RDP.mkape
+++ b/Modules/EventLogs/EvtxECmd-RDP.mkape
@@ -1,7 +1,7 @@
 Description: 'EvtxECmd: process event log files'
 Category: EventLogs
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: d6ddc918-feb1-47b6-8e51-e9c50936ec75
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
 ExportFormat: csv

--- a/Modules/EventLogs/EvtxECmd.mkape
+++ b/Modules/EventLogs/EvtxECmd.mkape
@@ -1,7 +1,7 @@
 Description: 'EvtxECmd: process event log files'
 Category: EventLogs
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 1b66f0e2-2ccf-467d-ae15-a2b3dc59df08
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
 ExportFormat: csv

--- a/Modules/EventLogs/PowershellOperationalFullEventLogView.mkape
+++ b/Modules/EventLogs/PowershellOperationalFullEventLogView.mkape
@@ -1,7 +1,7 @@
 Description: Parses PowerShell-Operational event log using Nirsoft FullEventLogView.exe
 Category: EventLogs
 Author: Barrie Hill
-Version: 1
+Version: 1.0
 Id: 3189c1e4-a76d-4bd6-a16b-a7e7fb821635
 BinaryUrl: https://www.nirsoft.net/utils/fulleventlogview-x64.zip
 ExportFormat: csv

--- a/Modules/EventLogs/PrintServiceOperationalFullEventLogView.mkape
+++ b/Modules/EventLogs/PrintServiceOperationalFullEventLogView.mkape
@@ -1,7 +1,7 @@
 Description: Parses Microsoft-Windows-PrintService%4Operational event log using Nirsoft FullEventLogView.exe
 Category: EventLogs
 Author: Barrie Hill
-Version: 1
+Version: 1.0
 Id: 10c90348-bf0d-436d-815b-e3c63ae6218e
 BinaryUrl: https://www.nirsoft.net/utils/fulleventlogview-x64.zip
 ExportFormat: csv

--- a/Modules/EventLogs/RDP-Usage-events.mkape
+++ b/Modules/EventLogs/RDP-Usage-events.mkape
@@ -1,7 +1,7 @@
 Description: LogParser RDP Usage Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational 21,22,23,24,25,39,40 and Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational 1149
 Category: RemoteAccess
 Author: Brian Maloney (idea by @0x47617279)
-Version: 1
+Version: 1.0
 Id: 058b60b0-6d1e-4b1b-8426-7418e40b6a4f
 BinaryUrl: https://www.microsoft.com/en-us/download/confirmation.aspx?id=24659
 ExportFormat: csv

--- a/Modules/EventLogs/SMB-Server-Anonymous-Logon.mkape
+++ b/Modules/EventLogs/SMB-Server-Anonymous-Logon.mkape
@@ -1,7 +1,7 @@
 Description: LogParser Microsoft-Windows-SMBServer-Security event 551
 Category: RemoteAccess
 Author: Hadar Yudovich
-Version: 1
+Version: 1.0
 Id: 7f4fed47-cd92-4a94-a2c0-b937ea218bc8
 BinaryUrl: https://www.microsoft.com/en-us/download/confirmation.aspx?id=24659
 ExportFormat: csv

--- a/Modules/EventLogs/ScheduledTasksFullEventLogView.mkape
+++ b/Modules/EventLogs/ScheduledTasksFullEventLogView.mkape
@@ -1,7 +1,7 @@
 Description: Parses TaskScheduler event log using Nirsoft FullEventLogView.exe
 Category: EventLogs
 Author: Hadar Yudovich
-Version: 1
+Version: 1.0
 Id: 8e04da5a-7ee4-4ef6-a4e0-4c68aca39af0
 BinaryUrl: https://www.nirsoft.net/utils/fulleventlogview-x64.zip
 ExportFormat: csv

--- a/Modules/EventLogs/SecurityFullEventLogView.mkape
+++ b/Modules/EventLogs/SecurityFullEventLogView.mkape
@@ -1,7 +1,7 @@
 Description: Parses Security event log using Nirsoft FullEventLogView.exe
 Category: EventLogs
 Author: Barrie Hill
-Version: 1
+Version: 1.0
 Id: 6f9da2e0-0c7c-4147-9a02-58622e4c1b34
 BinaryUrl: https://www.nirsoft.net/utils/fulleventlogview-x64.zip
 ExportFormat: csv

--- a/Modules/EventLogs/SystemFullEventLogView.mkape
+++ b/Modules/EventLogs/SystemFullEventLogView.mkape
@@ -1,7 +1,7 @@
 Description: Parses System event log using Nirsoft FullEventLogView.exe
 Category: EventLogs
 Author: Barrie Hill
-Version: 1
+Version: 1.0
 Id: bb628207-56cc-4293-aa6a-2073d406c8cb
 BinaryUrl: https://www.nirsoft.net/utils/fulleventlogview-x64.zip
 ExportFormat: csv

--- a/Modules/FileFolderAccess/JLECmd.mkape
+++ b/Modules/FileFolderAccess/JLECmd.mkape
@@ -1,7 +1,7 @@
 Description: 'JLECmd: process jumplist files'
 Category: FileFolderAccess
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 81fe4336-eb10-4733-a770-cb57ec9bd108
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/JLECmd.zip
 ExportFormat: csv

--- a/Modules/FileFolderAccess/LECmd.mkape
+++ b/Modules/FileFolderAccess/LECmd.mkape
@@ -1,7 +1,7 @@
 Description: 'LECmd: process .lnk files'
 Category: FileFolderAccess
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 1b66f0e2-2ccf-449c-ae02-a1b3dc59df08
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/LECmd.zip
 ExportFormat: csv

--- a/Modules/FileFolderAccess/SBECmd.mkape
+++ b/Modules/FileFolderAccess/SBECmd.mkape
@@ -1,7 +1,7 @@
 Description: 'SBECmd: process shellbags'
 Category: FileFolderAccess
 Author: Barrie Hill
-Version: 1
+Version: 1.0
 Id: fe12cf94-dad8-4f1a-b09d-3e64614fe2de
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/ShellBagsExplorer.zip
 ExportFormat: csv

--- a/Modules/FileFolderAccess/WxTCmd.mkape
+++ b/Modules/FileFolderAccess/WxTCmd.mkape
@@ -1,7 +1,7 @@
 Description: 'WxTCmd.exe: process Windows Timeline/Activities Cache files'
 Category: FileFolderAccess
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 47b717ab-9a2f-4eb6-a79f-9f56b2c076c4
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/WxTCmd.zip
 ExportFormat: csv

--- a/Modules/FileSystem/MFTECmd.mkape
+++ b/Modules/FileSystem/MFTECmd.mkape
@@ -1,7 +1,7 @@
 Description: 'MFTECmd: process all files handled by MFTECmd'
 Category: FileSystem
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 7ef84a6b-5215-47bb-af2a-2139a3277e25
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
 ExportFormat: csv

--- a/Modules/FileSystem/MFTECmd_$Boot.mkape
+++ b/Modules/FileSystem/MFTECmd_$Boot.mkape
@@ -1,7 +1,7 @@
 Description: 'MFTECmd: process $Boot files'
 Category: FileSystem
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 7ef84a6b-2215-47bb-af2a-3339a3227e25
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
 ExportFormat: csv

--- a/Modules/FileSystem/MFTECmd_$J.mkape
+++ b/Modules/FileSystem/MFTECmd_$J.mkape
@@ -1,7 +1,7 @@
 Description: 'MFTECmd: process $J files'
 Category: FileSystem
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 5ef67a6b-5895-46bb-af2a-3339a3227e25
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
 ExportFormat: csv

--- a/Modules/FileSystem/MFTECmd_$MFT.mkape
+++ b/Modules/FileSystem/MFTECmd_$MFT.mkape
@@ -1,7 +1,7 @@
 Description: 'MFTECmd: process $MFT files'
 Category: FileSystem
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 7ef84a6b-5215-46bb-af2a-3339a3227e25
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
 ExportFormat: csv

--- a/Modules/FileSystem/MFTECmd_$SDS.mkape
+++ b/Modules/FileSystem/MFTECmd_$SDS.mkape
@@ -1,7 +1,7 @@
 Description: 'MFTECmd: process $SDS files'
 Category: FileSystem
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 7ef84a6b-5215-46bb-af2a-3339a4247e41
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
 ExportFormat: csv

--- a/Modules/LiveResponse/ARPCache.mkape
+++ b/Modules/LiveResponse/ARPCache.mkape
@@ -1,7 +1,7 @@
 Description: ARPCache
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 6d4ea3be-f634-4809-b7d8-db0d22800737
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/DNSCache.mkape
+++ b/Modules/LiveResponse/DNSCache.mkape
@@ -1,7 +1,7 @@
 Description: DNSCache
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: b5df17b0-29d2-448f-bdaa-ec221bee29b6
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/DumpIt.mkape
+++ b/Modules/LiveResponse/DumpIt.mkape
@@ -1,7 +1,7 @@
 Description: DumpIt Memory Acquisition
 Category: Memory
 Author: Doug Metz 
-Version: 1
+Version: 1.0
 Id: 7504551a-41b6-4287-ad8a-ee0a10a66f7d
 BinaryUrl: https://my.comae.com
 ExportFormat: dmp

--- a/Modules/LiveResponse/Hashes.mkape
+++ b/Modules/LiveResponse/Hashes.mkape
@@ -1,7 +1,7 @@
 Description: Retrieve NTLM-hashes of all the user accounts
 Category: Passwords
 Author: Banaanhangwagen
-Version: 1
+Version: 1.0
 Id: 899fd6c5-c957-42cf-a4f7-d62f4430b6b2
 BinaryUrl: https://github.com/gentilkiwi/mimikatz/releases
 ExportFormat: txt

--- a/Modules/LiveResponse/IPConfig.mkape
+++ b/Modules/LiveResponse/IPConfig.mkape
@@ -1,7 +1,7 @@
 Description: IPConfig
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 5afdfd6b-5ebb-4545-9980-88e6f421e508
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/NBTStat_NetBIOS_Cache.mkape
+++ b/Modules/LiveResponse/NBTStat_NetBIOS_Cache.mkape
@@ -1,7 +1,7 @@
 Description: NBTStat_NETBIOS_Cache
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: d0309794-03b1-40bf-bbdd-12fe77f5e0a6
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/NBTStat_NetBIOS_Sessions.mkape
+++ b/Modules/LiveResponse/NBTStat_NetBIOS_Sessions.mkape
@@ -1,7 +1,7 @@
 Description: NBTStat_NETBIOS_Sessions
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 340d77a6-a9bd-400b-b3b6-bdd5a2085e3c
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/NetStat.mkape
+++ b/Modules/LiveResponse/NetStat.mkape
@@ -1,7 +1,7 @@
 Description: NetStat
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: ea773d1a-0a69-432d-ab3a-45a0d87374b8
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/NetworkDetails.mkape
+++ b/Modules/LiveResponse/NetworkDetails.mkape
@@ -1,7 +1,7 @@
 Description: Network Details
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 77b87364-39b1-46ff-b355-3d6fa8da9560
 ExportFormat: txt
 FileMask: ""

--- a/Modules/LiveResponse/ProcessDetails.mkape
+++ b/Modules/LiveResponse/ProcessDetails.mkape
@@ -1,7 +1,7 @@
 Description: Combination Module for LiveResponse. Gathering Running Process Details
 Category: LiveResponse
 Author: piesecurity
-Version: 1
+Version: 1.0
 Id: 337a4733-5549-4d3e-818e-8c4c6b0381de
 ExportFormat: txt
 FileMask: ""

--- a/Modules/LiveResponse/RoutingTable.mkape
+++ b/Modules/LiveResponse/RoutingTable.mkape
@@ -1,7 +1,7 @@
 Description: RoutingTable
 Category: LiveResponse
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 8aaad838-be9e-43d4-8643-145ceaa4208b
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/SigCheck.mkape
+++ b/Modules/LiveResponse/SigCheck.mkape
@@ -1,7 +1,7 @@
 Description: Sigcheck all files in a volume, with hashes, entropy, and internal metadata
 Category: FileMetadata
 Author: troyla@microsoft.com
-Version: 1
+Version: 1.0
 Id: f93bd081-55cd-4c13-9a7f-280a0caeebf8
 BinaryUrl: https://download.sysinternals.com/files/Sigcheck.zip
 ExportFormat: csv

--- a/Modules/LiveResponse/WinPmem.mkape
+++ b/Modules/LiveResponse/WinPmem.mkape
@@ -1,7 +1,7 @@
 Description: WinPmem Memory Dump
 Category: Memory
 Author: Eric Capuano 
-Version: 3
+Version: 3.0
 Id: 1d284835-417b-459e-a396-d228edea3808
 BinaryUrl: https://github.com/Velocidex/c-aff4/releases/download/3.2/winpmem_3.2.exe
 ExportFormat: dmp

--- a/Modules/LiveResponse/handle.mkape
+++ b/Modules/LiveResponse/handle.mkape
@@ -1,7 +1,7 @@
 Description: Handle is a utility that displays information about open handles for any process in the system.
 Category: LiveResponse
 Author: Andy Furnas
-Version: 1
+Version: 1.0
 Id: de522157-2cde-46ff-b1b0-d2201fba6554
 BinaryUrl: https://download.sysinternals.com/files/Handle.zip
 ExportFormat: txt

--- a/Modules/LiveResponse/manage-bde.mkape
+++ b/Modules/LiveResponse/manage-bde.mkape
@@ -1,7 +1,7 @@
 Description: Check for BitLocker volumes
 Category: VolumeInformation
 Author: troyla@microsoft.com
-Version: 1
+Version: 1.0
 Id: b069705b-13f0-42c7-86a2-4f310c3c651b
 ExportFormat: txt
 Processors:

--- a/Modules/LiveResponse/psfile.mkape
+++ b/Modules/LiveResponse/psfile.mkape
@@ -1,7 +1,7 @@
 Description: PsFile is a command-line utility that shows a list of files on a system that are opened remotely, and it also allows you to close opened files either by name or by a file identifier.
 Category: LiveResponse
 Author: Andy Furnas
-Version: 1
+Version: 1.0
 Id: 79cca355-160d-4a61-951d-e295a8c0d8bb
 BinaryUrl: https://download.sysinternals.com/files/PSTools.zip
 ExportFormat: txt

--- a/Modules/LiveResponse/psinfo.mkape
+++ b/Modules/LiveResponse/psinfo.mkape
@@ -1,7 +1,7 @@
 Description: PsInfo is a command-line tool that gathers key information about the local or remote Windows NT/2000 system, including the type of installation, kernel build, registered organization and owner, number of processors and their type, amount of physical memory, the install date of the system, and if its a trial version, the expiration date.
 Category: LiveResponse
 Author: Andy Furnas
-Version: 1
+Version: 1.0
 Id: 9e89b787-bc97-4e96-b72e-195a390ede98
 BinaryUrl: https://download.sysinternals.com/files/PSTools.zip
 ExportFormat: csv

--- a/Modules/LiveResponse/pslist.mkape
+++ b/Modules/LiveResponse/pslist.mkape
@@ -1,7 +1,7 @@
 Description: Shows statistics for all running processes
 Category: LiveResponse
 Author: Andy Furnas
-Version: 1
+Version: 1.0
 Id: fa3aa32a-0091-4650-9485-ad87891b8751
 BinaryUrl: https://download.sysinternals.com/files/PSTools.zip
 ExportFormat: txt

--- a/Modules/LiveResponse/psloggedon.mkape
+++ b/Modules/LiveResponse/psloggedon.mkape
@@ -1,7 +1,7 @@
 Description: PsLoggedOn is an applet that displays both the locally logged on users and users logged on via resources for either the local computer, or a remote one.
 Category: LiveResponse
 Author: Andy Furnas
-Version: 1
+Version: 1.0
 Id: 7b71f318-468e-4616-9ed2-dfd750b6b960
 BinaryUrl: https://download.sysinternals.com/files/PSTools.zip
 ExportFormat: txt

--- a/Modules/LiveResponse/psservice.mkape
+++ b/Modules/LiveResponse/psservice.mkape
@@ -1,7 +1,7 @@
 Description: Display the configured services (both running and stopped) on the local system.
 Category: LiveResponse
 Author: Andy Furnas
-Version: 1
+Version: 1.0
 Id: b5af1e38-2a78-4538-8430-83b8a60e02c4
 BinaryUrl: https://download.sysinternals.com/files/PSTools.zip
 ExportFormat: txt

--- a/Modules/LiveResponse/pstree.mkape
+++ b/Modules/LiveResponse/pstree.mkape
@@ -1,7 +1,7 @@
 Description: Shows a basic process tree for all running processes
 Category: LiveResponse
 Author: piesecurity
-Version: 1
+Version: 1.0
 Id: df6c02c1-d4b9-4e84-a4f6-7dd3f67a319d
 BinaryUrl: https://download.sysinternals.com/files/PSTools.zip
 ExportFormat: txt

--- a/Modules/LiveResponse/tcpvcon.mkape
+++ b/Modules/LiveResponse/tcpvcon.mkape
@@ -1,7 +1,7 @@
 Description: TCPView provides a more informative and conveniently presented subset of the Netstat program that ships with Windows.
 Category: LiveResponse
 Author: Andy Furnas
-Version: 1
+Version: 1.0
 Id: 528beed4-5703-454b-a4e8-879b8daecfd5
 BinaryUrl: https://download.sysinternals.com/files/TCPView.zip
 ExportFormat: csv

--- a/Modules/Memory/Volatility_amcache.mkape
+++ b/Modules/Memory/Volatility_amcache.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: df9c3a2d-bea4-4a86-808e-08bbe712fcb1
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_clipboard.mkape
+++ b/Modules/Memory/Volatility_clipboard.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 3d64e6ad-e574-49e7-b227-6ae787e871ae
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_cmdline.mkape
+++ b/Modules/Memory/Volatility_cmdline.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: a22fbcf0-c0d3-40b1-8df7-26169c265e58
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_cmdscan.mkape
+++ b/Modules/Memory/Volatility_cmdscan.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: e6bffba9-e023-48e3-9355-997175da0d37
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_connections.mkape
+++ b/Modules/Memory/Volatility_connections.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 5620ba3d-7d23-4670-b765-be00cdf11274
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_connscan.mkape
+++ b/Modules/Memory/Volatility_connscan.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: da81007a-5a63-4fa8-aa74-f958893d1a83
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_consoles.mkape
+++ b/Modules/Memory/Volatility_consoles.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: cdc796f3-6627-496c-9636-d51db65f636c
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_dlllist.mkape
+++ b/Modules/Memory/Volatility_dlllist.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: d311a46f-113d-4274-81e2-c4f536f85bfa
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_driverirp.mkape
+++ b/Modules/Memory/Volatility_driverirp.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 65418efa-cae6-40c0-8e9c-a15ac32e5a8a
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_hollowfind.mkape
+++ b/Modules/Memory/Volatility_hollowfind.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 2d966a97-a950-48b1-8219-e784ffb3a552
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_idt.mkape
+++ b/Modules/Memory/Volatility_idt.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: efc76bc6-2c27-492f-be24-fb532bf20d10
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_malfind.mkape
+++ b/Modules/Memory/Volatility_malfind.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 5afeec46-890c-4510-8a95-f36c7ddf2fde
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_modscan.mkape
+++ b/Modules/Memory/Volatility_modscan.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 62658f4a-9ca1-498d-81b8-85f61e18e8ab
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_modules.mkape
+++ b/Modules/Memory/Volatility_modules.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: e68cd71f-074f-470d-a7ce-8196bdd21ee4
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_netscan.mkape
+++ b/Modules/Memory/Volatility_netscan.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: dfa01514-aaba-41f3-a60c-74a3d2952bf7
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_notepad.mkape
+++ b/Modules/Memory/Volatility_notepad.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: abdb5baa-9693-4742-9444-7bd6f7f08942
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_pslist.mkape
+++ b/Modules/Memory/Volatility_pslist.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: de03554f-fe9f-4bd6-ac3b-8920be4ff609
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_psscan.mkape
+++ b/Modules/Memory/Volatility_psscan.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 6485072f-9ba9-4538-b713-d5dcf93ffdf9
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_pstree.mkape
+++ b/Modules/Memory/Volatility_pstree.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 750ea28d-1b96-4cd2-8399-eee4245eb6be
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_psxview.mkape
+++ b/Modules/Memory/Volatility_psxview.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 0e25fb2e-a197-4c2f-a839-6b2128a4ef2b
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_shimcache.mkape
+++ b/Modules/Memory/Volatility_shimcache.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: ca3f78e2-98b1-4099-8b00-0912e64ce616
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_sockets.mkape
+++ b/Modules/Memory/Volatility_sockets.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 5b5a957d-8c2d-4790-ad19-d6101903f8de
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_sockscan.mkape
+++ b/Modules/Memory/Volatility_sockscan.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 3915788a-4513-4951-ac3d-02daaf6a46a9
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_ssdt.mkape
+++ b/Modules/Memory/Volatility_ssdt.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: b4c02e2f-5223-4c3a-9f8a-9022e40ae1d5
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_userassist.mkape
+++ b/Modules/Memory/Volatility_userassist.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: bbcd1c2c-6802-4b1d-8c35-2856f8ce3bb6
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Memory/Volatility_userhandles.mkape
+++ b/Modules/Memory/Volatility_userhandles.mkape
@@ -1,7 +1,7 @@
 Description: Post-Process memory images with Volatility
 Category: Memory
 Author: Jos Clephas
-Version: 1
+Version: 1.0
 Id: 65ddfd53-f445-49a5-bc58-82e85f6c2cfb
 BinaryUrl: http://downloads.volatilityfoundation.org/releases/2.6/volatility_2.6_win64_standalone.zip
 ExportFormat: greptext

--- a/Modules/Misc/Apache_Access_Log.mkape
+++ b/Modules/Misc/Apache_Access_Log.mkape
@@ -1,7 +1,7 @@
 Description: LogParser Apache Access Log
 Category: Webservers
 Author: Hadar Yudovich
-Version: 1
+Version: 1.0
 Id: 631ac549-9ddf-48ea-b95b-ca4678230df6
 BinaryUrl: https://www.microsoft.com/en-us/download/confirmation.aspx?id=24659
 ExportFormat: csv

--- a/Modules/Misc/DensityScout.mkape
+++ b/Modules/Misc/DensityScout.mkape
@@ -1,7 +1,7 @@
 Description: DensityScout
 Category: FileMetadata
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: f93bd081-55cd-4c12-8a7f-280a0caeebf9
 BinaryUrl: https://www.cert.at/media/files/downloads/software/densityscout/files/densityscout_build_45_windows.zip
 ExportFormat: txt

--- a/Modules/Misc/KAPE_Automation.mkape
+++ b/Modules/Misc/KAPE_Automation.mkape
@@ -1,7 +1,7 @@
 Description: 'Module to run for KAPE automation'
 Category: --module
 Author: Brian Maloney
-Version: 1
+Version: 1.0
 Id: 06cfa868-31f3-43e9-826a-abd199987770
 ExportFormat: ""
 Processors:

--- a/Modules/Misc/RBCmd.mkape
+++ b/Modules/Misc/RBCmd.mkape
@@ -1,7 +1,7 @@
 Description: 'RBCmd: process recycle bin artifacts'
 Category: FileDeletion
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 7ef84a6b-5115-45bb-aa5b-2249a3237e75
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RBCmd.zip
 ExportFormat: csv

--- a/Modules/Misc/SEPM_Logs.mkape
+++ b/Modules/Misc/SEPM_Logs.mkape
@@ -1,7 +1,7 @@
 Description: Symantec Logs
 Category: AntiVirus
 Author: Brian Maloney
-Version: 1
+Version: 1.0
 Id: 073300a3-2d16-4bf5-b332-b038b571e95f
 BinaryUrl: https://github.com/Beercow/SEPparser/raw/master/bin/SEPparser.exe
 ExportFormat: csv

--- a/Modules/Misc/Snap2HTML.mkape
+++ b/Modules/Misc/Snap2HTML.mkape
@@ -1,7 +1,7 @@
 Description: 'Directory Lister - HTML Browser'
 Category: DirectoryLister
 Author: Dennis Reneau
-Version: 1
+Version: 1.0
 Id: 0ca2b18d-b886-497c-a57a-ea4442c878e2
 BinaryUrl: https://www.rlvision.com/script/download.php?ref=rlv.com&file=Snap2HTML.zip
 ExportFormat: html

--- a/Modules/Misc/TaskScheduler.mkape
+++ b/Modules/Misc/TaskScheduler.mkape
@@ -1,7 +1,7 @@
 Description: Parses TaskScheduler-Operational event log using TZWorks evtwalk64
 Category: SystemActivity
 Author: Justin Price
-Version: 1
+Version: 1.0
 Id: 5875f69b-4de1-418b-b306-db49b9fc0072
 BinaryUrl: https://tzworks.net/download_links.php
 ExportFormat: csv

--- a/Modules/Misc/TeraCopy-history.mkape
+++ b/Modules/Misc/TeraCopy-history.mkape
@@ -1,7 +1,7 @@
 Description: Parses the history file databases for TeraCopy history
 Category: FileKnowledge
 Author: Kevin Pagano
-Version: 1
+Version: 1.0
 Id: d77856a2-b657-4be7-88a8-5dffc32e8983
 BinaryUrl: https://sqlite.org/2019/sqlite-tools-win32-x86-3270200.zip
 ExportFormat: csv

--- a/Modules/Misc/TeraCopy-main.mkape
+++ b/Modules/Misc/TeraCopy-main.mkape
@@ -1,7 +1,7 @@
 Description: Parses the main.db for TeraCopy history
 Category: FileKnowledge
 Author: Kevin Pagano
-Version: 1
+Version: 1.0
 Id: 1ae7d97b-cb8e-4e29-8aec-3514f30e6919
 BinaryUrl: https://sqlite.org/2019/sqlite-tools-win32-x86-3270200.zip
 ExportFormat: csv

--- a/Modules/Misc/ThorLite.mkape
+++ b/Modules/Misc/ThorLite.mkape
@@ -1,7 +1,7 @@
 Description: Thor Lite, an IOC and YARA scanner written in Golang
 Category: IOCs
 Author: Jonas A. Wendorf (changes), based on the original for Spark Core by Eric Capuano 
-Version: 1
+Version: 1.0
 Id: bc310a24-c824-464a-abde-077bbe85c949
 BinaryUrl: https://www.nextron-systems.com/thor-lite/
 ExportFormat: csv

--- a/Modules/Misc/ThumbCacheParser.mkape
+++ b/Modules/Misc/ThumbCacheParser.mkape
@@ -1,7 +1,7 @@
 Description: 'thumbcache_viewer_cmd.exe: process Windows Thumbcache files'
 Category: FileKnowledge
 Author: Dennis Reneau
-Version: 1
+Version: 1.0
 Id: 8896483c-563a-4a28-ad8a-07ba74a54a63
 BinaryUrl: https://github.com/thumbcacheviewer/thumbcacheviewer/releases/download/v1.0.1.7/thumbcache_viewer_cmd.zip
 ExportFormat: html

--- a/Modules/Misc/exiftool.mkape
+++ b/Modules/Misc/exiftool.mkape
@@ -1,7 +1,7 @@
 Description: 'Exiftool: process files'
 Category: ExifData
 Author: Lee Whitfield
-Version: 1
+Version: 1.0
 Id: 1b66f0e2-2ccf-415c-ae13-a1b3dc59df08
 BinaryUrl: https://exiftool.org/exiftool-11.99.zip
 ExportFormat: csv

--- a/Modules/Misc/iTunesBackup.mkape
+++ b/Modules/Misc/iTunesBackup.mkape
@@ -1,7 +1,7 @@
 Description: 'iTunes Backup Reader'
 Category: ExternalDevices
 Author: Jack Farley
-Version: 1
+Version: 1.0
 Id: e2dbd037-69b5-476a-bbc6-9bcb737d76d4
 BinaryUrl: https://github.com/jfarley248/iTunes_Backup_Analyzer/releases
 ExportFormat: db

--- a/Modules/Misc/srum-dump.mkape
+++ b/Modules/Misc/srum-dump.mkape
@@ -1,7 +1,7 @@
 Description: 'SRUM-dump: Dump contents of the srum database'
 Category: SystemActivity
 Author: Brian Maloney
-Version: 1
+Version: 1.0	
 Id: 8e0a2314-79e4-48f2-81ad-a0719e8af680
 BinaryUrl: https://github.com/MarkBaggett/srum-dump/raw/python3/srum_dump_csv.exe
 ExportFormat: csv

--- a/Modules/ProgramExecution/AmcacheParser.mkape
+++ b/Modules/ProgramExecution/AmcacheParser.mkape
@@ -1,7 +1,7 @@
 Description: 'AmcacheParser: extract program execution information'
 Category: ProgramExecution
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 4190c518-524f-4623-8038-a014784c018c
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/AmcacheParser.zip
 ExportFormat: csv

--- a/Modules/ProgramExecution/AppCompatCacheParser.mkape
+++ b/Modules/ProgramExecution/AppCompatCacheParser.mkape
@@ -1,7 +1,7 @@
 Description: 'AppCompatCacheParser: extract AppCompatCache (shimcache) information'
 Category: ProgramExecution
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: e5e0ffa8-fe3e-4196-ac5a-d21cbeb879c2
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/AppCompatCacheParser.zip
 ExportFormat: csv

--- a/Modules/ProgramExecution/CCM-RUA.mkape
+++ b/Modules/ProgramExecution/CCM-RUA.mkape
@@ -1,7 +1,7 @@
 Description: 'Extracts SCCM software metering RecentlyUsedApplication logs from OBJECTS.DATA files'
 Category: ProgramExecution
 Author: Brian Maloney
-Version: 1
+Version: 1.0
 Id: 591b2715-f4eb-47bd-9a6c-249b8c22aba1
 BinaryUrl: https://github.com/esecrpm/WMI_Forensics/raw/master/CCM_RUA_Finder.exe
 ExportFormat: tsv

--- a/Modules/ProgramExecution/PECmd.mkape
+++ b/Modules/ProgramExecution/PECmd.mkape
@@ -1,7 +1,7 @@
 Description: 'PECmd: process prefetch files'
 Category: ProgramExecution
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 7ef84a6b-5115-45bb-af2a-3249a3237e75
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/PECmd.zip
 ExportFormat: csv

--- a/Modules/ProgramExecution/RecentFileCacheParser.mkape
+++ b/Modules/ProgramExecution/RecentFileCacheParser.mkape
@@ -1,7 +1,7 @@
 Description: 'RecentFileCacheParser: extract file names from RecentFilecache.bcf'
 Category: ProgramExecution
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 32fa31cc-8be6-4a1d-917a-97fbdff552ef
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RecentFileCacheParser.zip
 ExportFormat: csv

--- a/Modules/Registry/RegRipper-ALL.mkape
+++ b/Modules/Registry/RegRipper-ALL.mkape
@@ -1,7 +1,7 @@
 Description: 'RegRipper: parse all supported hives'
 Category: Registry
 Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
-Version: 1
+Version: 1.0
 Id: 76037ee9-0346-459a-a44a-1b67edc711c8
 BinaryUrl: https://github.com/keydet89/RegRipper2.8
 ExportFormat: txt

--- a/Modules/Registry/Registry_System.mkape
+++ b/Modules/Registry/Registry_System.mkape
@@ -1,7 +1,7 @@
 Description: 'CAFAE: extract registry information'
 Category: Registry
-Author: Scot Downie
-Version: 1
+Author: Scott Downie
+Version: 1.0
 Id: 5405e8ff-e40f-407c-9c73-224b09ef57ba
 BinaryUrl: https://tzworks.net/download_links.php
 ExportFormat: txt

--- a/Modules/timelining/EVT_System_TLN.mkape
+++ b/Modules/timelining/EVT_System_TLN.mkape
@@ -1,7 +1,7 @@
 Description: Parses System event log (EVT) into TLN format
 Category: Timeline
 Author: Mari DeGrazia
-Version: 1
+Version: 1.0
 Id: f3d7f0ae-f42e-4f4d-b50f-e037f3955971
 BinaryUrl: https://github.com/keydet89/Tools/raw/master/exe/evtparse.exe
 ExportFormat: csv

--- a/Modules/timelining/Mini_Timeline.mkape
+++ b/Modules/timelining/Mini_Timeline.mkape
@@ -1,7 +1,7 @@
 Description: Parses MFT, Registy and Event Logs into mini-timeline; Add in key "computerName" 
 Category: Timeline
 Author: Mari DeGrazia
-Version: 1
+Version: 1.0
 Id: 50415221-4267-47e4-985f-346a709e8b8e
 ExportFormat: ""
 FileMask: ""

--- a/Modules/timelining/RegRipper_AppCompatCache_TLN.mkape
+++ b/Modules/timelining/RegRipper_AppCompatCache_TLN.mkape
@@ -1,7 +1,7 @@
 Description: 'RegRipper: parse appcompatcache hive into TLN format'
 Category: Timeline
 Author: Mari DeGrazia
-Version: 1
+Version: 1.0
 Id: 680dfc07-07af-48a8-9bda-06eab3136baf
 BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
 ExportFormat: txt

--- a/Targets/!Disabled/DirectoryTraversalWildCardExample.tkape
+++ b/Targets/!Disabled/DirectoryTraversalWildCardExample.tkape
@@ -1,6 +1,6 @@
 Description: Find zip archives
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 9878f1fc-5e22-46a0-8cfd-c921ac9c4b13
 RecreateDirectories: true
 Targets:

--- a/Targets/!Disabled/LiveUserFiles.tkape
+++ b/Targets/!Disabled/LiveUserFiles.tkape
@@ -1,6 +1,6 @@
 Description: Live User Files
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: 2a5cb2e6-20e0-495b-9b6d-8728ac210584
 RecreateDirectories: true
 Targets:

--- a/Targets/Antivirus/McAfee_ePO.tkape
+++ b/Targets/Antivirus/McAfee_ePO.tkape
@@ -1,6 +1,6 @@
 Description: McAfee ePO Log Files
 Author: Doug Metz
-Version: 1
+Version: 1.0
 Id: 8e893785-6bf2-4990-a783-35b0f5e1b442
 RecreateDirectories: True
 Targets:

--- a/Targets/Apps/BoxDrive.tkape
+++ b/Targets/Apps/BoxDrive.tkape
@@ -1,6 +1,6 @@
 Description: Box Cloud Storage Files and Metadata
 Author: Chad Tilbury
-Version: 1
+Version: 1.0
 Id: 2e3bee53-24b6-4867-8510-7da07d353abc
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/ConfluenceLogs.tkape
+++ b/Targets/Apps/ConfluenceLogs.tkape
@@ -1,6 +1,6 @@
 Description: Confluence Log Files
 Author: Eric Capuano
-Version: 1
+Version: 1.0
 Id: 317b3814-b383-4bcf-97a2-3b3d1c5f8ca0
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/Discord.tkape
+++ b/Targets/Apps/Discord.tkape
@@ -1,6 +1,6 @@
 Description: Discord Cache and LevelDB Files
 Author: Christian Johansen and Matt Dawson
-Version: 2
+Version: 2.0
 Id: 5a44a0ef-db56-4103-8748-797432487028
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/Dropbox.tkape
+++ b/Targets/Apps/Dropbox.tkape
@@ -1,6 +1,6 @@
 Description: Dropbox Cloud Storage Files and Metadata
 Author: Chad Tilbury
-Version: 1
+Version: 1.0
 Id: e8501b5d-2cfc-4693-923d-52edd2ddf3bc
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/ExchangeClientAccess.tkape
+++ b/Targets/Apps/ExchangeClientAccess.tkape
@@ -1,6 +1,6 @@
 Description: Exchange Client Access Log Files
 Author: Keith Twombley
-Version: 1
+Version: 1.0
 Id: 9e802154-53eb-4cc9-9cca-d2e39f3227d7
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/ExchangeTransport.tkape
+++ b/Targets/Apps/ExchangeTransport.tkape
@@ -1,6 +1,6 @@
 Description: Exchange Transport Log Files
 Author: Keith Twombley
-Version: 1
+Version: 1.0
 Id: 9bc0a453-50ab-46e8-a424-09dc7022c4a4
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/FileZilla.tkape
+++ b/Targets/Apps/FileZilla.tkape
@@ -1,6 +1,6 @@
 Description: FileZilla XML and SQLite Log Files
 Author: Dennis Reneau
-Version: 1
+Version: 1.0
 Id: f7eaa0d5-0b15-4578-b411-ac4226e13a7f
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/GoogleDrive.tkape
+++ b/Targets/Apps/GoogleDrive.tkape
@@ -1,6 +1,6 @@
 Description: Google Drive Storage Files and Metadata
 Author: Chad Tilbury
-Version: 1
+Version: 1.0
 Id: 34f115e0-687e-49c1-acdd-85cc68a86157
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/JavaWebCache.tkape
+++ b/Targets/Apps/JavaWebCache.tkape
@@ -1,6 +1,6 @@
 Description: Java WebStart Cache - (IDX Files)
 Author: piesecurity
-Version: 1
+Version: 1.0
 Id: 4dc2e35c-fc20-45f6-89a6-5d729596c522
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/MacriumReflect.tkape
+++ b/Targets/Apps/MacriumReflect.tkape
@@ -1,0 +1,32 @@
+Description: Macrium Reflect
+Author: Andrew Rathbun
+Version: 1.0
+Id: def63ed5-a10d-4508-9c6b-d32658de8dbd
+RecreateDirectories: true
+Targets:
+    -
+        Name: Macrium Reflect
+        Category: Apps
+        Path: C:\ProgramData\Macrium\Macrium Service\
+        Comment: "Copies out all log files"
+    -
+        Name: Macrium Reflect
+        Category: Apps
+        Path: C:\ProgramData\Macrium\Reflect\
+        Comment: "Copies out the Reflect folder which contains many important logs"
+    -
+        Name: Macrium Reflect
+        Category: Apps
+        Path: C:\ProgramData\Macrium\Reflect Launcher
+        Comment: "Copies out the Reflect folder which contains many important logs"
+
+######
+# Macrium Reflect is a program that can be used to create full, incremental, and differential backups of any disk/volume on a user's system.
+# Often times, backups are automated and scheduled through Scheduled Tasks. 
+# If you notice there are Scheduled Tasks (ScheduledTasks.tkape) for Macrium Reflect, then this target is for you!
+# This target will copy out all log files that'll show when and where backups were made.
+# Another location to check for Macrium Reflect artifacts is Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree in the SOFTWARE registry hive.
+# .\Macrium\Reflect\ contains a Consolidate.log file, which contains a play-by-play of when backups occur and their destination. There will also be daily logs for scheduled backups. 
+# .\Macrium\Macrium Service\ contains logs that are similar to running --debug or --trace in KAPE, which provide more information than you really need. 
+# .\Macrium\Macrium Launcher\ contains logs that give a play-by-play of the program's events on a given day. 
+######

--- a/Targets/Apps/OneDrive.tkape
+++ b/Targets/Apps/OneDrive.tkape
@@ -1,6 +1,6 @@
 Description: Microsoft OneDrive Storage Files and Metadata
 Author: Chad Tilbury
-Version: 1
+Version: 1.0
 Id: f3c680ca-0646-48cc-a471-5f484e22b1cf
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/OutlookPSTOST.tkape
+++ b/Targets/Apps/OutlookPSTOST.tkape
@@ -1,6 +1,6 @@
 Description: Outlook PST and OST files
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: f91909c4-bba1-40d6-a3bc-39d060843a09
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/Skype.tkape
+++ b/Targets/Apps/Skype.tkape
@@ -1,6 +1,6 @@
 Description: Skype
 Author: Eric Zimmerman
-Version: 3
+Version: 3.0
 Id: d7b0b49c-16bb-4b32-9f57-2d918acaebbc
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/SublimeText.tkape
+++ b/Targets/Apps/SublimeText.tkape
@@ -1,6 +1,6 @@
 Description: Sublime Text 2/3 Auto Save Session
 Author: Mathias Frank
-Version: 1
+Version: 1.0
 Id: c1a64d12-bdf3-4ebe-a715-719bd6f2ddad
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/Telegram.tkape
+++ b/Targets/Apps/Telegram.tkape
@@ -1,6 +1,6 @@
 Description: Telegram Desktop
 Author: Simone Marinari
-Version: 1
+Version: 1.0
 Id: 7f836137-1479-46b4-91a9-83624b8a8e26
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/TeraCopy.tkape
+++ b/Targets/Apps/TeraCopy.tkape
@@ -1,6 +1,6 @@
 Description: 'TeraCopy log history'
 Author: Kevin Pagano
-Version: 1
+Version: 1.0
 Id: 111ee9ac-f8b3-4026-a3c9-90f76b6b2cb4
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/VMwareMemory.tkape
+++ b/Targets/Apps/VMwareMemory.tkape
@@ -1,6 +1,6 @@
 Description: VMware - Virtual Machine Memory
 Author: Andrew Rathbun
-Version: 1
+Version: 1.0
 Id: 45945262-2e36-47c7-a36f-3cf4124dbe63
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/VirtualBoxMemory.tkape
+++ b/Targets/Apps/VirtualBoxMemory.tkape
@@ -1,6 +1,6 @@
 Description: VirtualBox - Memory
 Author: Andrew Rathbun
-Version: 1
+Version: 1.0
 Id: 4af61e3f-7fa7-4c59-a6d7-a495582fbb56
 RecreateDirectories: true
 Targets:

--- a/Targets/Apps/iTunesBackup.tkape
+++ b/Targets/Apps/iTunesBackup.tkape
@@ -1,6 +1,6 @@
 Description: iTunes Backups
 Author: Tony Knutson
-Version: 2
+Version: 2.0
 Id: 7b4a98d9-b36a-40be-bacc-ad0102b0a8c3
 RecreateDirectories: true
 Targets:

--- a/Targets/Browsers/ChromeExtensions.tkape
+++ b/Targets/Browsers/ChromeExtensions.tkape
@@ -1,6 +1,6 @@
 Description: Chrome Extension Files
 Author: piesecurity
-Version: 1
+Version: 1.0
 Id: e748b5e3-e279-4e4d-8083-74293e5b6cde
 RecreateDirectories: true
 Targets:

--- a/Targets/Browsers/Edge.tkape
+++ b/Targets/Browsers/Edge.tkape
@@ -1,6 +1,6 @@
 Description: Edge
 Author: Phill Moore
-Version: 1
+Version: 1.0
 Id: c72bd45c-2a24-4df9-aa0b-3d7048c90337
 RecreateDirectories: true
 Targets:

--- a/Targets/Browsers/InternetExplorer.tkape
+++ b/Targets/Browsers/InternetExplorer.tkape
@@ -1,6 +1,6 @@
 Description: Internet Explorer
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: b1e1d79b-324d-4587-a002-cc81144588ff
 RecreateDirectories: true
 Targets:

--- a/Targets/Browsers/PuffinSecureBrowser.tkape
+++ b/Targets/Browsers/PuffinSecureBrowser.tkape
@@ -1,0 +1,59 @@
+Description: Puffin Secure Browser
+Author: Andrew Rathbun
+Version: 1.0
+Id: 0adfdd1e-16e7-4b2e-808a-8643f42ebe16
+RecreateDirectories: true
+Targets:
+    -
+        Name: Puffin - data.db
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\PuffinSecureBrowser
+        FileMask: data.db
+        Comment: "Grabs an important database file that contains browser history"
+    -
+        Name: Puffin - Autocomplete Data
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\PuffinSecureBrowser
+        FileMask: autocompletes.dat
+        Comment: "Grabs a file that stores autocomplete data"
+    -
+        Name: Puffin - Password Forms Data
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\PuffinSecureBrowser
+        FileMask: passwordForms.dat
+        Comment: "Grabs a file that stores some saved password data"
+    -
+        Name: Puffin - Password (Encrypted)
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\PuffinSecureBrowser
+        FileMask: credential.dat
+        Comment: "Grabs a file that stores passwords in an encrypted format"
+    -
+        Name: Puffin - Subscription Data
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\PuffinSecureBrowser
+        FileMask: subscription
+        Comment: "Grabs a file that stores the user's email address that's associated with their Puffin subscription"
+    -
+        Name: Puffin - Cookies
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\PuffinSecureBrowser
+        FileMask: cookies.dat
+        Comment: "Grabs a file that stores information related to cookies"
+    -
+        Name: Puffin - Image Cache
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\PuffinSecureBrowser\image_cache
+        Recursive: True
+        Comment: "Grabs a directory that caches images from websites visited"
+
+######
+# Puffin is a secure web browser that takes a LOT of work to get set up. If your suspect is using this, they went out of their way to make this their browser of choice. I had to use a credit card/billing address, authorization codes sent to my fake email, sign in multiple times to activate the browser and my membership, etc. It was a pain.
+# As secure as Puffin claims to be, they store some stuff locally! 
+# Data.db had evidence of tabs I had opened with the browser.
+# Autocompletes.dat stored some autocomplete data (email, etc) that I entered throughout the setup process.
+# passwordForms.dat stored the email in plaintext but the password itself is not in plain text. 
+# "subscription" was a file without a file extension (viewable in a text editor) that showed the fake email I used to set up my trial with Puffin. 
+# The image_cache folder will store what appears to be .JPG files but as .ci0 files. I was able to view all the images with IrfanView despite the proprietary file extension.
+######
+

--- a/Targets/Compound/!BasicCollection.tkape
+++ b/Targets/Compound/!BasicCollection.tkape
@@ -1,6 +1,6 @@
 Description: Basic Collection
 Author: Phill Moore
-Version: 1
+Version: 1.0
 Id: 83b99299-2d84-4844-af25-c727d3440b19
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/!SANS_Triage.tkape
+++ b/Targets/Compound/!SANS_Triage.tkape
@@ -3,7 +3,7 @@ Description: SANS Triage Collection.
 # "self documenting" for the SANS 500 Students.
 
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: 5dbe9218-fd3d-4d86-88aa-56001d38e7f5
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/CloudStorage.tkape
+++ b/Targets/Compound/CloudStorage.tkape
@@ -1,6 +1,6 @@
 Description: Cloud Storage Contents and Metadata
 Author: Chad Tilbury
-Version: 1
+Version: 1.0
 Id: 29984028-0f42-4922-8a3f-752341f5852c
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/CombinedLogs.tkape
+++ b/Targets/Compound/CombinedLogs.tkape
@@ -1,6 +1,6 @@
 Description: Collect Event logs, Trace logs, Windows Firewall and PowerShell console
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: 6e9f717f-01f8-4460-b552-a3a0ec7d7670
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/EvidenceOfExecution.tkape
+++ b/Targets/Compound/EvidenceOfExecution.tkape
@@ -1,6 +1,6 @@
 Description: Evidence of execution related files
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 13ba1e33-4899-4843-adf0-c7e6a20d758a
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/Exchange.tkape
+++ b/Targets/Compound/Exchange.tkape
@@ -1,6 +1,6 @@
 Description: Exchange Log Files
 Author: Keith Twombley
-Version: 1
+Version: 1.0
 Id: 1b54aafe-5074-4d45-b129-29107ce7f863
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/FileSystem.tkape
+++ b/Targets/Compound/FileSystem.tkape
@@ -1,6 +1,6 @@
 Description: File system metadata
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 2bd97ef7-5fbf-4427-8ca2-ffb15d545b00
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/MiniTimelineCollection.tkape
+++ b/Targets/Compound/MiniTimelineCollection.tkape
@@ -1,6 +1,6 @@
 Description: MFT, Registry and Event Logs to generate a mini timeline
 Author: Mari DeGrazia
-Version: 1
+Version: 1.0
 Id: 02e131d6-7784-4302-9495-75536423e414
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/RegistryHives.tkape
+++ b/Targets/Compound/RegistryHives.tkape
@@ -1,6 +1,6 @@
 Description: System and user related Registry hives
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 76af6086-bd0b-429f-bfd7-4a8e8ff8138f
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/WSL.tkape
+++ b/Targets/Compound/WSL.tkape
@@ -1,6 +1,6 @@
 Description: All Windows Subsystem for Linux targets
 Author: Matt Dawson
-Version: 1
+Version: 1.0
 Id: 6f1d49c3-e558-4d59-bf33-5ce8bb611102
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/WebBrowsers.tkape
+++ b/Targets/Compound/WebBrowsers.tkape
@@ -1,6 +1,6 @@
 Description: Web browser history, bookmarks, etc.
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: e4ffb938-dcc0-4d91-9c77-3aa303d38512
 RecreateDirectories: true
 Targets:

--- a/Targets/Compound/WebBrowsers.tkape
+++ b/Targets/Compound/WebBrowsers.tkape
@@ -24,3 +24,7 @@ Targets:
         Name: Opera
         Category: Communications
         Path: Opera.tkape
+    -
+        Name: Puffin Secure Browser
+        Category: Communications
+        Path: PuffinSecureBrowser.tkape

--- a/Targets/Logs/ApacheAccessLog.tkape
+++ b/Targets/Logs/ApacheAccessLog.tkape
@@ -1,6 +1,6 @@
 Description: Apache Access Log
 Author: Hadar Yudovich
-Version: 1
+Version: 1.0
 Id: 6ad85ab3-701a-409c-98b8-ea4ef806cdf0
 RecreateDirectories: true
 Targets:

--- a/Targets/Logs/IISLogFiles.tkape
+++ b/Targets/Logs/IISLogFiles.tkape
@@ -1,6 +1,6 @@
 Description: IIS Log Files
 Author: Troy Larson
-Version: 2
+Version: 2.0
 Id: 701573f6-0ce1-454d-af41-612713e22af5
 RecreateDirectories: true
 Targets:

--- a/Targets/Logs/MSSQLErrorLog.tkape
+++ b/Targets/Logs/MSSQLErrorLog.tkape
@@ -1,6 +1,6 @@
 Description: MS SQL ErrorLogs
 Author: Troy Larson
-Version: 1
+Version: 1.0
 Id: cb789cbf-bf4a-4491-b6d9-9e2d002bd85e
 RecreateDirectories: true
 Targets:

--- a/Targets/Logs/ManageEngineLogs.tkape
+++ b/Targets/Logs/ManageEngineLogs.tkape
@@ -1,6 +1,6 @@
 Description: ManageEngine Desktop Central Log Files
 Author: Whitney Champion
-Version: 1
+Version: 1.0
 Id: c034ee17-a97f-48a1-b720-c73867ed66e6
 RecreateDirectories: true
 Targets:

--- a/Targets/Logs/NGINXLogs.tkape
+++ b/Targets/Logs/NGINXLogs.tkape
@@ -1,6 +1,6 @@
 Description: NGINX Log Files
 Author: Eric Capuano
-Version: 1
+Version: 1.0
 Id: d5c2cfd9-a8a5-400e-8be5-a8e9b5653a51
 RecreateDirectories: true
 Targets:

--- a/Targets/Logs/PowerShellConsole.tkape
+++ b/Targets/Logs/PowerShellConsole.tkape
@@ -1,6 +1,6 @@
 Description: PowerShell Console Log File
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: efa4332a-89eb-430c-ab61-006a9e6620d7
 RecreateDirectories: true
 Targets:

--- a/Targets/P2P/Gigatribe.tkape
+++ b/Targets/P2P/Gigatribe.tkape
@@ -1,6 +1,6 @@
 Description: Gigatribe Files
 Author: Linus Nissi
-Version: 2
+Version: 2.0
 Id: 64726d74-1a68-463a-bb26-929054a20b71
 RecreateDirectories: true
 Targets:

--- a/Targets/P2P/TorrentClients.tkape
+++ b/Targets/P2P/TorrentClients.tkape
@@ -1,6 +1,6 @@
 Description: Torrent Clients
 Author: Banaanhangwagen
-Version: 1
+Version: 1.0
 Id: c43f37fb-1b2f-437c-8595-b5b095a0ca7b
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/$Boot.tkape
+++ b/Targets/Windows/$Boot.tkape
@@ -1,6 +1,6 @@
 Description: $Boot
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 9f24d727-fcf0-492d-97cc-108472eb4e00
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/$J.tkape
+++ b/Targets/Windows/$J.tkape
@@ -1,6 +1,6 @@
 Description: $J
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 2a9c6f80-250b-42a6-9d29-90cb0a20f7be
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/$LogFile.tkape
+++ b/Targets/Windows/$LogFile.tkape
@@ -1,6 +1,6 @@
 Description: $LogFile
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: b98612e0-f679-400a-954f-c0b2bc86147b
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/$MFT.tkape
+++ b/Targets/Windows/$MFT.tkape
@@ -1,6 +1,6 @@
 Description: $MFT
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 2b3d01e2-25e1-4079-a630-6cb6e2069456
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/$MFTMirr.tkape
+++ b/Targets/Windows/$MFTMirr.tkape
@@ -1,6 +1,6 @@
 Description: $MFTMirr
 Author: Teo Kia Meng
-Version: 1
+Version: 1.0
 Id: 8fce369c-a773-41c4-8ca3-ba9df1f72ba0
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/$SDS.tkape
+++ b/Targets/Windows/$SDS.tkape
@@ -1,6 +1,6 @@
 Description: $SDS
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 72d56db2-b8da-4830-a2e7-37437c90e18f
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/$T.tkape
+++ b/Targets/Windows/$T.tkape
@@ -1,6 +1,6 @@
 Description: $T
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 8c568aa0-9a67-4035-9720-1423770bc29a
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/Amcache.tkape
+++ b/Targets/Windows/Amcache.tkape
@@ -1,6 +1,6 @@
 Description: Amcache.hve
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 13ba1e33-4899-4843-adf1-c7e6b20d759a
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/BCD.tkape
+++ b/Targets/Windows/BCD.tkape
@@ -1,6 +1,6 @@
 Description: Boot Configuration Files
 Author: Troy Larson
-Version: 1
+Version: 1.0
 Id: eedec61a-bae4-4e96-a2cd-b6b30aa5a786
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/EncapsulationLogging.tkape
+++ b/Targets/Windows/EncapsulationLogging.tkape
@@ -1,6 +1,6 @@
 Description: EncapsulationLogging
 Author: Troy Larson
-Version: 1
+Version: 1.0
 Id: 7c328d9b-4a10-459d-b8b3-36d81686bc74
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/EventLogs-RDP.tkape
+++ b/Targets/Windows/EventLogs-RDP.tkape
@@ -1,6 +1,6 @@
 Description: Collect Win7+ RDP related Event logs
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: 2e79fc64-816c-439a-8b7f-93dd59bf2711
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/EventLogs.tkape
+++ b/Targets/Windows/EventLogs.tkape
@@ -1,6 +1,6 @@
 Description: Event logs
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: d95784d9-bd1c-472b-aeef-de5d9ecc7aaa
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/EventTraceLogs.tkape
+++ b/Targets/Windows/EventTraceLogs.tkape
@@ -1,6 +1,6 @@
 Description: Event Trace Logs
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: af494526-9e44-4548-9d29-f088eafa6f3d
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/GroupPolicy.tkape
+++ b/Targets/Windows/GroupPolicy.tkape
@@ -1,6 +1,6 @@
 Description: Current Group Policy Enforcement
 Author: piesecurity
-Version: 1
+Version: 1.0
 Id: e5595e9c-ebab-41db-a688-fdffe91f6fcb
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/LinuxOnWindowsProfileFiles.tkape
+++ b/Targets/Windows/LinuxOnWindowsProfileFiles.tkape
@@ -1,6 +1,6 @@
 Description: Linux on Windows Profile Files
 Author: Troy Larson
-Version: 1
+Version: 1.0
 Id: 9718a129-21f9-4354-a06f-2eddb112ab03
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/LogFiles.tkape
+++ b/Targets/Windows/LogFiles.tkape
@@ -1,6 +1,6 @@
 Description: LogFiles
 Author: Fabian Murer
-Version: 1
+Version: 1.0
 Id: 67c9bb8d-342b-4380-a110-565317fce014
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/MemoryFiles.tkape
+++ b/Targets/Windows/MemoryFiles.tkape
@@ -1,6 +1,6 @@
 Description: Memory Files
 Author: Ahmed Elshaer, Teo Kia Meng
-Version: 1
+Version: 1.0
 Id: d9e7fc93-7b63-4286-aa05-27ce3437c9c0
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/OfficeAutosave.tkape
+++ b/Targets/Windows/OfficeAutosave.tkape
@@ -1,6 +1,6 @@
 Description: Office Autosave
 Author: Russ Taylor
-Version: 1
+Version: 1.0
 Id: 71f1efe7-37be-4285-9896-11f0f6be2770
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/OfficeDocumentCache.tkape
+++ b/Targets/Windows/OfficeDocumentCache.tkape
@@ -1,6 +1,6 @@
 Description: Office Document Cache
 Author: Banaanhangwagen
-Version: 1
+Version: 1.0
 Id: 15e92d9c-b02d-4cdf-a86e-bafb3d25af5c
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/Prefetch.tkape
+++ b/Targets/Windows/Prefetch.tkape
@@ -1,6 +1,6 @@
 Description: Prefetch files
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: f6715d3f-b8ca-4cc2-9e5e-4ed18e88abbe
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/RDPCache.tkape
+++ b/Targets/Windows/RDPCache.tkape
@@ -1,6 +1,6 @@
 Description: RDP Cache Files
 Author: Hadar Yudovich
-Version: 1
+Version: 1.0
 Id: 527a5de1-fb71-4efd-9701-89a30ea908e3
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/RecentFileCache.tkape
+++ b/Targets/Windows/RecentFileCache.tkape
@@ -1,6 +1,6 @@
 Description: Amcache.hve
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 0d93d3fc-1b09-4894-b21f-dddc7f269934
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/RecycleBin.tkape
+++ b/Targets/Windows/RecycleBin.tkape
@@ -1,6 +1,6 @@
 Description: Recycle Bin
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: 336abbbb-e9db-4d04-8904-43718e57df85
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/RegistryHivesSystem.tkape
+++ b/Targets/Windows/RegistryHivesSystem.tkape
@@ -1,6 +1,6 @@
 Description: System level/related Registry hives
 Author: Eric Zimmerman / Mark Hallman
-Version: 1
+Version: 1.0
 Id: 2b7f40fd-cd02-47da-87da-9966fa5d8159
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/RegistryHivesUser.tkape
+++ b/Targets/Windows/RegistryHivesUser.tkape
@@ -1,6 +1,6 @@
 Description: User Related Registry hives
 Author: Eric Zimmerman / Mark Hallman
-Version: 1
+Version: 1.0
 Id: 635fbfd3-4a47-45b5-aae4-0a1bb6545d08
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/SDB.tkape
+++ b/Targets/Windows/SDB.tkape
@@ -1,6 +1,6 @@
 Description: Shim SDB FIles
 Author: Troy Larson
-Version: 1
+Version: 1.0
 Id: 99e82a85-e4d4-4139-930c-7eea9a45452f
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/SRUM.tkape
+++ b/Targets/Windows/SRUM.tkape
@@ -1,6 +1,6 @@
 Description: System Resource Usage Monitor (SRUM) Data
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: 9858f1fc-5e22-46a0-8bfd-c821ac9b4a13
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/ScheduledTasks.tkape
+++ b/Targets/Windows/ScheduledTasks.tkape
@@ -1,6 +1,6 @@
 Description: Scheduled tasks (*.job and XML)
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: e5dc4367-2e6b-49bf-a90a-d4c1598bbe28
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/SignatureCatalog.tkape
+++ b/Targets/Windows/SignatureCatalog.tkape
@@ -1,6 +1,6 @@
 Description: Obtain detached signature catalog files
 Author: Mike Pilkington
-Version: 1
+Version: 1.0
 Id: 953b16e8-69ea-4967-9f9b-bcfa4f4fbe7b
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/StartupInfo.tkape
+++ b/Targets/Windows/StartupInfo.tkape
@@ -1,6 +1,6 @@
 Description: StartupInfo XML Files
 Author: Hadar Yudovich
-Version: 1
+Version: 1.0
 Id: 9bb477a3-fa6f-410d-8646-c3f987c147ce
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/Syscache.tkape
+++ b/Targets/Windows/Syscache.tkape
@@ -1,6 +1,6 @@
 Description: syscache.hve
 Author: Phill Moore
-Version: 1
+Version: 1.0
 Id: d4665b13-9953-4cf0-bdc4-6fcb7a37842f
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/ThumbCache.tkape
+++ b/Targets/Windows/ThumbCache.tkape
@@ -1,6 +1,6 @@
 Description: Thumbcache DB
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 1eec8849-b6eb-475b-a700-f4fb0055356d
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/USBDevicesLogs.tkape
+++ b/Targets/Windows/USBDevicesLogs.tkape
@@ -1,6 +1,6 @@
 Description: USB devices log files
 Author: Eric Zimmerman
-Version: 1
+Version: 1.0
 Id: 07ee308f-c79a-47de-a431-c93ab34e4b66
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/VirtualDisks.tkape
+++ b/Targets/Windows/VirtualDisks.tkape
@@ -1,6 +1,6 @@
 Description: Virtual Disks
 Author: Phill Moore
-Version: 1
+Version: 1.0
 Id: 283fd2b7-b914-4683-85b4-40dd3fefecbb
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/WBEM.tkape
+++ b/Targets/Windows/WBEM.tkape
@@ -1,6 +1,6 @@
 Description: Web-Based Enterprise Management (WBEM)
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: e985f5e3-f951-4e13-8099-a2a6877355cb
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/WER.tkape
+++ b/Targets/Windows/WER.tkape
@@ -1,6 +1,6 @@
 Description: Windows Error Reporting
 Author: Troy Larson
-Version: 1
+Version: 1.0
 Id: 03106a1c-e1f8-4075-abdb-f9c83078347d
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/WindowsFirewall.tkape
+++ b/Targets/Windows/WindowsFirewall.tkape
@@ -1,6 +1,6 @@
 Description: Windows Firewall Logs
 Author: Mike Cary
-Version: 1
+Version: 1.0
 Id: e1c2040e-c1b4-47ef-973f-73a54c5e87ca
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/WindowsIndexSearch.tkape
+++ b/Targets/Windows/WindowsIndexSearch.tkape
@@ -1,6 +1,6 @@
 Description: Windows Index Search
 Author: Mark Hallman
-Version: 1
+Version: 1.0
 Id: 9828b927-f955-464a-80fb-a48ce0101236
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/WindowsNotificationsDB.tkape
+++ b/Targets/Windows/WindowsNotificationsDB.tkape
@@ -1,6 +1,6 @@
 Description: Windows 10 Notification DB
 Author: Hadar Yudovich
-Version: 1
+Version: 1.0
 Id: a5c3308d-8941-43c4-a295-b906a59bc895
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/WindowsTimeline.tkape
+++ b/Targets/Windows/WindowsTimeline.tkape
@@ -1,6 +1,6 @@
 Description: ActivitiesCache.db collector
 Author: Lee Whitfield
-Version: 1
+Version: 1.0
 Id: 8315040f-c9a4-455a-b02c-96372583f436
 RecreateDirectories: true
 Targets:

--- a/Targets/Windows/XPRestorePoints.tkape
+++ b/Targets/Windows/XPRestorePoints.tkape
@@ -1,6 +1,6 @@
 Description: XP Restore Points - System Volume Information directory
 Author: Phill Moore
-Version: 1
+Version: 1.0
 Id: 07f57a75-f9d9-42f3-842c-bd7e5abbb569
 RecreateDirectories: true
 Targets:


### PR DESCRIPTION
## Description

Add Macrium Reflect target and update Version to create a uniform standard, i.e. 1.0, 2.0, 3.0 instead of 1, 2, or 3. 

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
