### PR TITLE
Create AcronisTrueImage.tkape

### DIFF
--- a/Targets/Apps/AcronisTrueImage.tkape
+++ b/Targets/Apps/AcronisTrueImage.tkape
@@ -1,0 +1,31 @@
+Description: Acronis True Image
+Author: Andrew Rathbun
+Version: 1.0
+Id: 4f984e18-81fb-4520-9a01-69bf77a0f459
+RecreateDirectories: true
+Targets:
+    -
+        Name: Acronis True Image - Logs
+        Category: Apps
+        Path: C:\ProgramData\Acronis\TrueImageHome\Logs\ti_demon\
+        Comment: "Copies out all log files"
+    -
+        Name: Acronis True Image - Database Files
+        Category: Apps
+        Path: C:\ProgramData\Acronis\TrueImageHome\Database
+        FileMask: archives.db*
+        Comment: "Copies out the Database folder which appears to have important information"
+    -
+        Name: Acronis True Image - Scripts Folder
+        Category: Apps
+        Path: C:\ProgramData\Acronis\TrueImageHome\Scripts\
+        Comment: "Copies out all scripts files"
+
+######
+# Acronis True Image can be used to create full, incremental, and differential backups of any disk/volume on a user's system.
+# .\Acronis\TrueImageHome\Logs\ti_demon\ will contain logs that are prepended with ti_demon_ followed by what appears to be either a GUID or gibberish followed by a YYYY-MM-DD-HH-MM-SS timestamp prior to the .log file extension.
+# Every time a backup process is started, a log file is created following this naming convention. 
+# .\Acronis\TrueImageHome\Database\ had a .opt file that I was able to view in a text editor that showed the source and destination for the backup job I created in my testing. It was nested under the "backup_archive_operation_options" with each being on a line that started with "volume_location". 
+# The Database folder target should get you the files I saw on my system that were relevant (Archives.db, Archives.db-shm, Archives.db-wal, Archives.db000000001h.opt). 
+# .\Acronis\TrueImageHome\Scripts\ contained .tib.tis files that were viewable in a text editor that appeared to have the contents of a batch script for running the backup I created in my testing.
+######


### PR DESCRIPTION
## Description

Create AcronisTrueImage.tkape. 

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
