### PR TITLE
Added Cybereason - Covers version 20.1

### DIFF
--- a/Targets/Antivirus/Cybereason.tkape
+++ b/Targets/Antivirus/Cybereason.tkape
@@ -19,3 +19,4 @@ Targets:
         Category: AntiVirus
         Path: C:\ProgramData\crb1
         Recursive: True
+        

--- a/Targets/Antivirus/Cybereason.tkape
+++ b/Targets/Antivirus/Cybereason.tkape
@@ -1,0 +1,21 @@
+Description: Cybereason Sensor/Detection Logs
+Author: piesecurity
+Version: 1.0
+Id: 73ddfac4-a50a-4fcf-9fa2-7eb360cfd896
+RecreateDirectories: True
+Targets:
+    -
+        Name: Cybereason Anti-Ransomware Logs
+        Category: AntiVirus
+        Path: C:\ProgramData\crs1
+        Recursive: True
+    -
+        Name: Cybereason Sensor Communications and Anti-Malware Logs
+        Category: AntiVirus
+        Path: C:\ProgramData\apv2\Logs
+        Recursive: True
+    -
+        Name: Cybereason Application Control and NGAV Logs
+        Category: AntiVirus
+        Path: C:\ProgramData\crb1
+        Recursive: True


### PR DESCRIPTION
## Description

Added Targets for Cybereason Sensor and Detection Logs. Taken from the latest documentation on - [Cybereason Nest](https://nest.cybereason.com/documentation/product-documentation/201/view-sensor-logs)

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have generated a unique GUID for my target(s)/module(s)
- [X] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
