### PR TITLE
Add target for Chromium Microsoft Edge

### DIFF
--- a/Targets/Browsers/EdgeChromium.tkape
+++ b/Targets/Browsers/EdgeChromium.tkape
@@ -1,0 +1,102 @@
+Description: Microsoft Edge Chromium Artifacts
+Author: Chad Tilbury
+Version: 1.0
+Id: 2844dba2-fb47-466c-8d57-dab2bc02294f
+RecreateDirectories: True
+Targets:
+    -
+        Name: Edge bookmarks
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Bookmarks*
+    -
+        Name: Edge Collections
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\Collections
+        FileMask: collectionsSQLite
+    -
+        Name: Edge Cookies
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Cookies*
+    -
+        Name: Edge Current Session
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Current Session
+    -
+        Name: Edge Current Tabs
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Current Tabs
+    -
+        Name: Edge Favicons
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Favicons*
+    -
+        Name: Edge History
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: History*
+    -
+        Name: Edge Last Session
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Last Session
+    -
+        Name: Edge Last Tabs
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Last Tabs
+    -
+        Name: Edge Login Data
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Login Data
+    -
+        Name: Edge Network Action Predictor
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Network Action Predictor
+    -
+        Name: Edge Preferences
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Preferences
+    -
+        Name: Edge Shortcuts
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Shortcuts*
+    -
+        Name: Edge Top Sites
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Top Sites*
+    -
+        Name: Edge SyncData Database
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\Sync Data
+        FileMask: SyncData.sqlite3
+    -
+        Name: Edge Bookmarks
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Bookmarks*
+    -
+        Name: Edge Visited Links
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Visited Links
+    -
+        Name: Edge Web Data
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Web Data*
+    -
+        Name: Windows Protect Folder
+        Category: FileSystem
+        Path: C:\Users\%user%\AppData\Roaming\Microsoft\Protect\*\
+        Recursive: True
+        Comment: "Required for offline DPAPI decryption"

--- a/Targets/Browsers/Firefox.tkape
+++ b/Targets/Browsers/Firefox.tkape
@@ -65,62 +65,72 @@ Targets:
         Path: C:\Users\%user%\AppData\Roaming\Mozilla\Firefox\Profiles\*\
         FileMask: logins.json
     -
-        Name: Places
+        Name: Sessionstore
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Roaming\Mozilla\Firefox\Profiles\*\
+        FileMask: sessionstore*
+    -
+        Name: Sessionstore Folder
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Roaming\Mozilla\Firefox\Profiles\*\sessionstore-backups
+        Recursive: True
+    -
+        Name: Places XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: places.sqlite*
     -
-        Name: Downloads
+        Name: Downloads XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: downloads.sqlite*
     -
-        Name: Form history
+        Name: Form history XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: formhistory.sqlite*
     -
-        Name: Cookies
+        Name: Cookies XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: cookies.sqlite*
     -
-        Name: Signons
+        Name: Signons XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: signons.sqlite*
     -
-        Name: Webappstore
+        Name: Webappstore XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: webappstore.sqlite*
     -
-        Name: Favicons
+        Name: Favicons XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: favicons.sqlite*
     -
-        Name: Addons
+        Name: Addons XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: addons.sqlite*
     -
-        Name: Search
+        Name: Search XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: search.sqlite*
     -
-        Name: Password
+        Name: Password XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: key*.db
     -
-        Name: Password
+        Name: Password XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: signon*.*
     -
-        Name: Password
+        Name: Password XP
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: logins.json

--- a/Targets/Browsers/Firefox.tkape
+++ b/Targets/Browsers/Firefox.tkape
@@ -134,3 +134,8 @@ Targets:
         Category: Communications
         Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
         FileMask: logins.json
+    -
+        Name: Sessionstore XP
+        Category: Communications
+        Path: C:\Documents and Settings\%user%\Application Data\Mozilla\Firefox\Profiles\*\
+        FileMask: sessionstore*

--- a/Targets/Compound/WebBrowsers.tkape
+++ b/Targets/Compound/WebBrowsers.tkape
@@ -21,6 +21,10 @@ Targets:
         Category: Communications
         Path: Edge.tkape
     -
+        Name: Edge Chromium
+        Category: Communications
+        Path: EdgeChromium.tkape
+    -
         Name: Opera
         Category: Communications
         Path: Opera.tkape


### PR DESCRIPTION
New target to collect artifacts from Chromium version of Microsoft Edge.  Also updated Web Browsers compound file.

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X ] I have generated a unique GUID for my target(s)/module(s)
- [X ] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
