### PR TITLE
Update TotalCommander.tkape

### DIFF
--- a/Targets/Apps/TotalCommander.tkape
+++ b/Targets/Apps/TotalCommander.tkape
@@ -49,4 +49,5 @@ Targets:
 #   9=C:\Program Files (x86)\BraveSoftware\	#01,Brave-Browser
 #   10=C:\Program Files (x86)\	#02,BraveSoftware
 # The totalcmd.log is the default filename by Total Commander for the log file which can track creation of folders, delete actions, archive packing and unpacking, etc. 
+# Within a user's NTUSER.DAT file, there will be a key with an address of: SOFTWARE\Ghisler\Total Commander. There will be a value for InstallDir which will list where TotalCommander is installed for that user. 
 ######


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my target(s)/module(s)
- [ ] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
