### PR TITLE
Update Cybereason.tkape to include missing Logs folders

### DIFF
--- a/Targets/Antivirus/Cybereason.tkape
+++ b/Targets/Antivirus/Cybereason.tkape
@@ -7,7 +7,7 @@ Targets:
     -
         Name: Cybereason Anti-Ransomware Logs
         Category: AntiVirus
-        Path: C:\ProgramData\crs1
+        Path: C:\ProgramData\crs1\Logs
         Recursive: True
     -
         Name: Cybereason Sensor Communications and Anti-Malware Logs
@@ -17,6 +17,6 @@ Targets:
     -
         Name: Cybereason Application Control and NGAV Logs
         Category: AntiVirus
-        Path: C:\ProgramData\crb1
+        Path: C:\ProgramData\crb1\Logs
         Recursive: True
         


### PR DESCRIPTION
Added Logs folder to crs1 and crb1 paths.

## Description

Added Logs folder to crs1 and crb1 paths.

## Checklist:

- [ N/A ] I have generated a unique GUID for my target(s)/module(s)
- [ N/A ] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ N/A ] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
