### PR TITLE
Update targets with proper Windows.old filepaths

### DIFF
--- a/Targets/Antivirus/Symantec_AV_Logs.tkape
+++ b/Targets/Antivirus/Symantec_AV_Logs.tkape
@@ -22,7 +22,13 @@ Targets:
     -
         Name: Symantec Event Log Win7+
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: Symantec Endpoint Protection Client.evtx
+        Comment: "Symantec specific Windows event log"
+    -
+        Name: Symantec Event Log Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: Symantec Endpoint Protection Client.evtx
         Comment: "Symantec specific Windows event log"
     -

--- a/Targets/Antivirus/WindowsDefender.tkape
+++ b/Targets/Antivirus/WindowsDefender.tkape
@@ -12,17 +12,25 @@ Targets:
     -
         Name: Windows Defender Event Logs
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\Logs\
+        Path: C:\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-Windows Defender*.evtx
+    -
+        Name: Windows Defender Event Logs
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\Logs\
         FileMask: Microsoft-Windows-Windows Defender*.evtx
     -
         Name: Windows Defender Logs
         Category: Antivirus
         Path: C:\ProgramData\Microsoft\Windows Defender\Support\
         Recursive: True
-
     -
         Name: Windows Defender Logs
         Category: Antivirus
-        Path: C:\Windows*\Temp\
+        Path: C:\Windows\Temp\
         FileMask: MpCmdRun.log
- 
+    -
+        Name: Windows Defender Logs
+        Category: Antivirus
+        Path: C:\Windows.old\Windows\Temp\
+        FileMask: MpCmdRun.log

--- a/Targets/Apps/JavaWebCache.tkape
+++ b/Targets/Apps/JavaWebCache.tkape
@@ -17,22 +17,42 @@ Targets:
     -
         Name: Java WebStart Cache System level
         Category: Communication
-        Path: C:\Windows*\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\
+        Path: C:\Windows\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\
+        FileMask: '*.idx'
+    -
+        Name: Java WebStart Cache System level
+        Category: Communication
+        Path: C:\Windows.old\Windows\System32\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\
         FileMask: '*.idx'
     -
         Name: Java WebStart Cache System level - IE Protected Mode
         Category: Communication
-        Path: C:\Windows*\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\
+        Path: C:\Windows\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\
+        FileMask: '*.idx'
+    -
+        Name: Java WebStart Cache System level - IE Protected Mode
+        Category: Communication
+        Path: C:\Windows.old\Windows\System32\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\
         FileMask: '*.idx'
     -
         Name: Java WebStart Cache System level (SysWow64)
         Category: Communication
-        Path: C:\Windows*\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\
+        Path: C:\Windows\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\
+        FileMask: '*.idx'
+    -
+        Name: Java WebStart Cache System level (SysWow64)
+        Category: Communication
+        Path: C:\Windows.old\Windows\SysWOW64\config\systemprofile\AppData\Local\Sun\Java\Deployment\cache\*\*\
         FileMask: '*.idx'
     -
         Name: Java WebStart Cache System level (SysWow64) - IE Protected Mode
         Category: Communication
-        Path: C:\Windows*\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\
+        Path: C:\Windows\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\
+        FileMask: '*.idx'
+    -
+        Name: Java WebStart Cache System level (SysWow64) - IE Protected Mode
+        Category: Communication
+        Path: C:\Windows.old\Windows\SysWOW64\config\systemprofile\AppData\LocalLow\Sun\Java\Deployment\cache\*\*\
         FileMask: '*.idx'
     -
         Name: Java WebStart Cache User Level - XP

--- a/Targets/Apps/Kaseya.tkape
+++ b/Targets/Apps/Kaseya.tkape
@@ -43,6 +43,12 @@ Targets:
     -
         Name: Kaseya Setup Log
         Category: ApplicationLogs
-        Path: C:\Windows*\Temp\
+        Path: C:\Windows\Temp\
+        FileMask: KASetup.log
+        Comment: "https://helpdesk.kaseya.com/hc/en-gb/articles/229011448"
+    -
+        Name: Kaseya Setup Log
+        Category: ApplicationLogs
+        Path: C:\Windows.old\Windows\Temp\
         FileMask: KASetup.log
         Comment: "https://helpdesk.kaseya.com/hc/en-gb/articles/229011448"

--- a/Targets/Compound/!SANS_Triage.tkape
+++ b/Targets/Compound/!SANS_Triage.tkape
@@ -3,7 +3,7 @@ Description: SANS Triage Collection.
 # "self documenting" for the SANS 500 Students.
 
 Author: Mark Hallman
-Version: 1.0
+Version: 1.1
 Id: 5dbe9218-fd3d-4d86-88aa-56001d38e7f5
 RecreateDirectories: True
 Targets:
@@ -17,29 +17,54 @@ Targets:
     -
         Name: Event logs Win7+
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: '*.evtx'
+    -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: '*.evtx'
 
 # Evidence of Execution
     -
         Name: Prefetch
         Category: Prefetch
-        Path: C:\Windows*\prefetch\
+        Path: C:\Windows\prefetch\
+        FileMask: '*.pf'
+    -
+        Name: Prefetch
+        Category: Prefetch
+        Path: C:\Windows.old\Windows\prefetch\
         FileMask: '*.pf'
     -
         Name: RecentFileCache
         Category: ApplicationCompatability
-        Path: C:\Windows*\AppCompat\Programs\
+        Path: C:\Windows\AppCompat\Programs\
+        FileMask: RecentFileCache.bcf
+    -
+        Name: RecentFileCache
+        Category: ApplicationCompatability
+        Path: C:\Windows.old\Windows\AppCompat\Programs\
         FileMask: RecentFileCache.bcf
     -
         Name: Amcache
         Category: ApplicationCompatibility
-        Path: C:\Windows*\AppCompat\Programs\
+        Path: C:\Windows\AppCompat\Programs\
+        FileMask: Amcache.hve
+    -
+        Name: Amcache
+        Category: ApplicationCompatibility
+        Path: C:\Windows.old\Windows\AppCompat\Programs\
         FileMask: Amcache.hve
     -
         Name: Amcache transaction files
         Category: ApplicationCompatibility
-        Path: C:\Windows*\AppCompat\Programs\
+        Path: C:\Windows\AppCompat\Programs\
+        FileMask: Amcache.hve.LOG*
+    -
+        Name: Amcache transaction files
+        Category: ApplicationCompatibility
+        Path: C:\Windows.old\Windows\AppCompat\Programs\
         FileMask: Amcache.hve.LOG*
     -
         Name: Syscache
@@ -154,103 +179,203 @@ Targets:
     -
         Name: SAM registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SAM.LOG*
+    -
+        Name: SAM registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SAM.LOG*
     -
         Name: SECURITY registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SECURITY.LOG*
+    -
+        Name: SECURITY registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SECURITY.LOG*
     -
         Name: SOFTWARE registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SOFTWARE.LOG*
+    -
+        Name: SOFTWARE registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SOFTWARE.LOG*
     -
         Name: SYSTEM registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SYSTEM.LOG*
+    -
+        Name: SYSTEM registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SYSTEM.LOG*
     -
         Name: SAM registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SAM
+    -
+        Name: SAM registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SAM
     -
         Name: SECURITY registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SECURITY
+    -
+        Name: SECURITY registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SECURITY
     -
         Name: SOFTWARE registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SOFTWARE
+    -
+        Name: SOFTWARE registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SOFTWARE
     -
         Name: SYSTEM registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SYSTEM
+    -
+        Name: SYSTEM registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SYSTEM
     -
         Name: RegBack registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: '*.LOG*'
+    -
+        Name: RegBack registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: '*.LOG*'
     -
         Name: SAM registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SAM
+    -
+        Name: SAM registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SAM
     -
         Name: SECURITY registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SECURITY
+    -
+        Name: SECURITY registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SECURITY
     -
         Name: SOFTWARE registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SOFTWARE
+    -
+        Name: SOFTWARE registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SOFTWARE
     -
         Name: SYSTEM registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
         FileMask: SYSTEM
     -
         Name: SYSTEM registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
+        FileMask: SYSTEM
+    -
+        Name: SYSTEM registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SYSTEM1
+    -
+        Name: SYSTEM registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SYSTEM1
     -
         Name: System Profile registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\systemprofile\
-        FileMask: ntuser.dat
+        Path: C:\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT
+    -
+        Name: System Profile registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT
     -
         Name: System Profile registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\systemprofile\
-        FileMask: ntuser.dat.LOG*
+        Path: C:\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT.LOG*
+    -
+        Name: System Profile registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT.LOG*
     -
         Name: Local Service registry hive
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\LocalService\
-        FileMask: ntuser.dat
+        Path: C:\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT
+    -
+        Name: Local Service registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT
     -
         Name: Local Service registry transaction files
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\LocalService\
-        FileMask: ntuser.dat.LOG*
+        Path: C:\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT.LOG*
+    -
+        Name: Local Service registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT.LOG*
     -
         Name: Network Service registry hive
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\NetworkService\
-        FileMask: ntuser.dat
+        Path: C:\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT
+    -
+        Name: Network Service registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT
     -
         Name: Network Service registry transaction files
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\NetworkService\
-        FileMask: ntuser.dat.LOG*
+        Path: C:\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT.LOG*
+    -
+        Name: Network Service registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT.LOG*
     -
         Name: System Restore Points Registry Hives (XP)
         Category: Registry
@@ -259,29 +384,39 @@ Targets:
 
 # User Registry Files
     -
-        Name: ntuser.dat registry hive XP
+        Name: NTUSER.DAT registry hive XP
         Category: Registry
         Path: C:\Documents and Settings\%user%\
-        FileMask: ntuser.dat
+        FileMask: NTUSER.DAT
     -
-        Name: ntuser.dat registry hive
+        Name: NTUSER.DAT registry hive
         Category: Registry
         Path: C:\Users\%user%\
-        FileMask: ntuser.dat
+        FileMask: NTUSER.DAT
     -
-        Name: ntuser.dat registry transaction files
+        Name: NTUSER.DAT registry transaction files
         Category: Registry
         Path: C:\Users\%user%\
-        FileMask: ntuser.dat.LOG*
+        FileMask: NTUSER.DAT.LOG*
     -
-        Name: ntuser.dat DEFAULT registry hive
+        Name: NTUSER.DAT DEFAULT registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
         FileMask: DEFAULT
     -
-        Name: ntuser.dat DEFAULT transaction files
+        Name: NTUSER.DAT DEFAULT registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows.old\Windows\System32\config\
+        FileMask: DEFAULT
+    -
+        Name: NTUSER.DAT DEFAULT transaction files
+        Category: Registry
+        Path: C:\Windows\System32\config\
+        FileMask: DEFAULT.LOG*
+    -
+        Name: NTUSER.DAT DEFAULT transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: DEFAULT.LOG*
     -
         Name: UsrClass.dat registry hive
@@ -300,23 +435,47 @@ Targets:
     -
         Name: at .job
         Category: Persistence
-        Path: C:\Windows*\Tasks\
+        Path: C:\Windows\Tasks\
+        FileMask: '*.job'
+    -
+        Name: at .job
+        Category: Persistence
+        Path: C:\Windows.old\Windows\Tasks\
         FileMask: '*.job'
     -
         Name: at SchedLgU.txt
         Category: Persistence
-        Path: C:\Windows*\Tasks\
+        Path: C:\Windows\
+        FileMask: SchedLgU.txt
+    -
+        Name: at SchedLgU.txt
+        Category: Persistence
+        Path: C:\Windows.old\Windows\
         FileMask: SchedLgU.txt
     -
         Name: XML
         Category: Persistence
-        Path: C:\Windows*\System32\Tasks\
+        Path: C:\Windows\System32\Tasks\
+        Recursive: True
+    -
+        Name: XML
+        Category: Persistence
+        Path: C:\Windows.old\Windows\System32\Tasks\
+        Recursive: True
+
+# System Resource Usage Monitor
+    -
+        Name: SRUM
+        Category: Execution
+        Path: C:\Windows\System32\SRU\
         Recursive: True
     -
         Name: SRUM
         Category: Execution
-        Path: C:\Windows*\System32\SRU\
+        Path: C:\Windows.old\Windows\System32\SRU\
         Recursive: True
+
+# Thumbcache.db
     -
         Name: Thumbcache DB
         Category: FileKnowledge
@@ -332,7 +491,12 @@ Targets:
     -
         Name: Setupapi.log Win7+
         Category: USBDevices
-        Path: C:\Windows*\inf\
+        Path: C:\Windows\inf\
+        FileMask: setupapi.dev.log
+    -
+        Name: Setupapi.log Win7+
+        Category: USBDevices
+        Path: C:\Windows.old\Windows\inf\
         FileMask: setupapi.dev.log
     -
         Name: WindowsIndexSearch
@@ -342,7 +506,12 @@ Targets:
     -
         Name: WBEM
         Category: WBEM
-        Path: C:\Windows*\System32\wbem\Repository\
+        Path: C:\Windows\System32\wbem\Repository\
+        Recursive: True
+    -
+        Name: WBEM
+        Category: WBEM
+        Path: C:\Windows.old\Windows\System32\wbem\Repository\
         Recursive: True
 
 # User Communication         

--- a/Targets/Logs/IISLogFiles.tkape
+++ b/Targets/Logs/IISLogFiles.tkape
@@ -7,7 +7,12 @@ Targets:
     -
         Name: IIS log files
         Category: Logs
-        Path: C:\Windows*\System32\LogFiles\W3SVC*\
+        Path: C:\Windows\System32\LogFiles\W3SVC*\
+        FileMask: '*.log'
+    -
+        Name: IIS log files
+        Category: Logs
+        Path: C:\Windows.old\Windows\System32\LogFiles\W3SVC*\
         FileMask: '*.log'
     -
         Name: IIS log files

--- a/Targets/Windows/Amcache.tkape
+++ b/Targets/Windows/Amcache.tkape
@@ -7,10 +7,20 @@ Targets:
     -
         Name: Amcache
         Category: ApplicationCompatibility
-        Path: C:\Windows*\AppCompat\Programs\
+        Path: C:\Windows\AppCompat\Programs\
+        FileMask: Amcache.hve
+    -
+        Name: Amcache
+        Category: ApplicationCompatibility
+        Path: C:\Windows.old\Windows\AppCompat\Programs\
         FileMask: Amcache.hve
     -
         Name: Amcache transaction files
         Category: ApplicationCompatibility
-        Path: C:\Windows*\AppCompat\Programs\
+        Path: C:\Windows\AppCompat\Programs\
+        FileMask: Amcache.hve.LOG*
+    -
+        Name: Amcache transaction files
+        Category: ApplicationCompatibility
+        Path: C:\Windows.old\Windows\AppCompat\Programs\
         FileMask: Amcache.hve.LOG*

--- a/Targets/Windows/ApplicationEvents.tkape
+++ b/Targets/Windows/ApplicationEvents.tkape
@@ -7,10 +7,20 @@ Targets:
     -
         Name: Application Event Log XP
         Category: EventLogs
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: AppEvent.evt
+    -
+        Name: Application Event Log XP
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: AppEvent.evt
     -
         Name: Application Event Log Win7+
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: application.evtx
+    -
+        Name: Application Event Log Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: application.evtx

--- a/Targets/Windows/EncapsulationLogging.tkape
+++ b/Targets/Windows/EncapsulationLogging.tkape
@@ -7,10 +7,20 @@ Targets:
     -
         Name: EncapsulationLogging
         Category: Executables
-        Path: C:\Windows*\Appcompat\Programs\
+        Path: C:\Windows\Appcompat\Programs\
+        FileMask: EncapsulationLogging.hve
+    -
+        Name: EncapsulationLogging
+        Category: Executables
+        Path: C:\Windows.old\Windows\Appcompat\Programs\
         FileMask: EncapsulationLogging.hve
     -
         Name: EncapsulationLogging Logs
         Category: Executables
-        Path: C:\Windows*\Appcompat\Programs\
+        Path: C:\Windows\Appcompat\Programs\
+        FileMask: EncapsulationLogging.hve.log*
+    -
+        Name: EncapsulationLogging Logs
+        Category: Executables
+        Path: C:\Windows.old\Windows\Appcompat\Programs\
         FileMask: EncapsulationLogging.hve.log*

--- a/Targets/Windows/EventLogs-RDP.tkape
+++ b/Targets/Windows/EventLogs-RDP.tkape
@@ -7,12 +7,22 @@ Targets:
     -
         Name: Event logs Win7+
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
         FileMask: System.evtx
     -
         Name: Event logs Win7+
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
+        FileMask: System.evtx
+    -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: Security.evtx
+    -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: Security.evtx
     -
         Name: Event logs Win7+

--- a/Targets/Windows/EventLogs.tkape
+++ b/Targets/Windows/EventLogs.tkape
@@ -12,5 +12,10 @@ Targets:
     -
         Name: Event logs Win7+
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: '*.evtx'
+    -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: '*.evtx'

--- a/Targets/Windows/EventTraceLogs.tkape
+++ b/Targets/Windows/EventTraceLogs.tkape
@@ -7,22 +7,42 @@ Targets:
     -
         Name: WDI Trace Logs 1
         Category: Event Trace Logs
-        Path: C:\Windows*\System32\WDI\LogFiles\
+        Path: C:\Windows\System32\WDI\LogFiles\
+        FileMask: '*.etl*'
+    -
+        Name: WDI Trace Logs 1
+        Category: Event Trace Logs
+        Path: C:\Windows.old\Windows\System32\WDI\LogFiles\
         FileMask: '*.etl*'
     -
         Name: WDI Trace Logs 2
         Category: Event Trace Logs
-        Path: C:\Windows*\System32\WDI\{*\
+        Path: C:\Windows\System32\WDI\{*\
+        Recursive: True
+    -
+        Name: WDI Trace Logs 2
+        Category: Event Trace Logs
+        Path: C:\Windows.old\Windows\System32\WDI\{*\
         Recursive: True
     -
         Name: WMI Trace Logs
         Category: Event Trace Logs
-        Path: C:\Windows*\System32\LogFiles\WMI\
+        Path: C:\Windows\System32\LogFiles\WMI\
+        Recursive: True
+    -
+        Name: WMI Trace Logs
+        Category: Event Trace Logs
+        Path: C:\Windows.old\Windows\System32\LogFiles\WMI\
         Recursive: True
     -
         Name: SleepStudy Trace Logs
         Category: Event Trace Logs
-        Path: C:\Windows*\System32\SleepStudy\
+        Path: C:\Windows\System32\SleepStudy\
+        Recursive: True
+    -
+        Name: SleepStudy Trace Logs
+        Category: Event Trace Logs
+        Path: C:\Windows.old\Windows\System32\SleepStudy\
         Recursive: True
     -
         Name: Energy-NTKL Trace Logs

--- a/Targets/Windows/GroupPolicy.tkape
+++ b/Targets/Windows/GroupPolicy.tkape
@@ -7,15 +7,30 @@ Targets:
     -
         Name: Local Group Policy INI Files
         Category: Communication
-        Path: C:\Windows*\System32\grouppolicy\
+        Path: C:\Windows\System32\grouppolicy\
+        FileMask: '*.ini'
+    -
+        Name: Local Group Policy INI Files
+        Category: Communication
+        Path: C:\Windows.old\Windows\System32\grouppolicy\
         FileMask: '*.ini'
     -
         Name: Local Group Policy Files - Registry Policy Files
         Category: Communication
-        Path: C:\Windows*\System32\grouppolicy\
+        Path: C:\Windows\System32\grouppolicy\
+        FileMask: '*.pol'
+    -
+        Name: Local Group Policy Files - Registry Policy Files
+        Category: Communication
+        Path: C:\Windows.old\Windows\System32\grouppolicy\
         FileMask: '*.pol'
     -
         Name: Local Group Policy Files - Startup/Shutdown Scripts
         Category: Communication
-        Path: C:\Windows*\System32\grouppolicy\*\Scripts\
+        Path: C:\Windows\System32\grouppolicy\*\Scripts\
+        Recursive: True
+    -
+        Name: Local Group Policy Files - Startup/Shutdown Scripts
+        Category: Communication
+        Path: C:\Windows.old\Windows\System32\grouppolicy\*\Scripts\
         Recursive: True

--- a/Targets/Windows/LogFiles.tkape
+++ b/Targets/Windows/LogFiles.tkape
@@ -7,6 +7,10 @@ Targets:
     -
         Name: LogFiles
         Category: Logs
-        Path: C:\Windows*\System32\LogFiles\
+        Path: C:\Windows\System32\LogFiles\
         Recursive: True
-
+    -
+        Name: LogFiles
+        Category: Logs
+        Path: C:\Windows.old\Windows\System32\LogFiles\
+        Recursive: True

--- a/Targets/Windows/MemoryFiles.tkape
+++ b/Targets/Windows/MemoryFiles.tkape
@@ -25,7 +25,12 @@ Targets:
     -
         Name: Small Memory Dump directory
         Category: Memory
-        Path: C:\Windows*\Minidump\     
+        Path: C:\Windows\Minidump\     
         FileMask: '*.dmp'
         Comment: "https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump"
-        
+    -
+        Name: Small Memory Dump directory
+        Category: Memory
+        Path: C:\Windows.old\Windows\Minidump\     
+        FileMask: '*.dmp'
+        Comment: "https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/small-memory-dump"

--- a/Targets/Windows/Prefetch.tkape
+++ b/Targets/Windows/Prefetch.tkape
@@ -7,5 +7,10 @@ Targets:
     -
         Name: Prefetch
         Category: Prefetch
-        Path: C:\Windows*\prefetch\
+        Path: C:\Windows\prefetch\
+        FileMask: '*.pf'
+    -
+        Name: Prefetch
+        Category: Prefetch
+        Path: C:\Windows.old\Windows\prefetch\
         FileMask: '*.pf'

--- a/Targets/Windows/RDPLogs.tkape
+++ b/Targets/Windows/RDPLogs.tkape
@@ -7,21 +7,42 @@ Targets:
     -
         Name: RemoteConnectionManager Event Logs
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: Microsoft-Windows-TerminalServices-RemoteConnectionManager*
+    -
+        Name: RemoteConnectionManager Event Logs
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: Microsoft-Windows-TerminalServices-RemoteConnectionManager*
     -
         Name: LocalSessionManager Event Logs
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: Microsoft-Windows-TerminalServices-LocalSessionManager*
+    -
+        Name: LocalSessionManager Event Logs
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: Microsoft-Windows-TerminalServices-LocalSessionManager*
     -
         Name: RDPClient Event Logs
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: Microsoft-Windows-TerminalServices-RDPClient*
+    -
+        Name: RDPClient Event Logs
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: Microsoft-Windows-TerminalServices-RDPClient*
     -
         Name: RDPCoreTS Event Logs
         Category: EventLogs
-        Path: C:\Windows*\System32\winevt\logs\
+        Path: C:\Windows\System32\winevt\logs\
+        FileMask: Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*
+        Comment: "Can be used to correlate RDP logon failures by originating IP"
+    -
+        Name: RDPCoreTS Event Logs
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\logs\
         FileMask: Microsoft-Windows-RemoteDesktopServices-RdpCoreTS*
         Comment: "Can be used to correlate RDP logon failures by originating IP"

--- a/Targets/Windows/RecentFileCache.tkape
+++ b/Targets/Windows/RecentFileCache.tkape
@@ -1,4 +1,4 @@
-Description: Amcache.hve
+Description: RecentFileCache
 Author: Eric Zimmerman
 Version: 1.0
 Id: 0d93d3fc-1b09-4894-b21f-dddc7f269934
@@ -7,5 +7,10 @@ Targets:
     -
         Name: RecentFileCache
         Category: ApplicationCompatability
-        Path: C:\Windows*\AppCompat\Programs\
+        Path: C:\Windows\AppCompat\Programs\
+        FileMask: RecentFileCache.bcf
+    -
+        Name: RecentFileCache
+        Category: ApplicationCompatability
+        Path: C:\Windows.old\Windows\AppCompat\Programs\
         FileMask: RecentFileCache.bcf

--- a/Targets/Windows/RegistryHivesSystem.tkape
+++ b/Targets/Windows/RegistryHivesSystem.tkape
@@ -7,105 +7,206 @@ Targets:
     -
         Name: SAM registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SAM.LOG*
+    -
+        Name: SAM registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SAM.LOG*
     -
         Name: SECURITY registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SECURITY.LOG*
+    -
+        Name: SECURITY registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SECURITY.LOG*
     -
         Name: SOFTWARE registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SOFTWARE.LOG*
+    -
+        Name: SOFTWARE registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SOFTWARE.LOG*
     -
         Name: SYSTEM registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SYSTEM.LOG*
+    -
+        Name: SYSTEM registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SYSTEM.LOG*
     -
         Name: SAM registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SAM
+    -
+        Name: SAM registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SAM
     -
         Name: SECURITY registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SECURITY
+    -
+        Name: SECURITY registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SECURITY
     -
         Name: SOFTWARE registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SOFTWARE
+    -
+        Name: SOFTWARE registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SOFTWARE
     -
         Name: SYSTEM registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
+        FileMask: SYSTEM
+    -
+        Name: SYSTEM registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: SYSTEM
     -
         Name: RegBack registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: '*.LOG*'
+    -
+        Name: RegBack registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: '*.LOG*'
     -
         Name: SAM registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SAM
+    -
+        Name: SAM registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SAM
     -
         Name: SECURITY registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SECURITY
+    -
+        Name: SECURITY registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SECURITY
     -
         Name: SOFTWARE registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SOFTWARE
+    -
+        Name: SOFTWARE registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SOFTWARE
     -
         Name: SYSTEM registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows\System32\config\RegBack\
         FileMask: SYSTEM
     -
         Name: SYSTEM registry hive (RegBack)
         Category: Registry
-        Path: C:\Windows*\System32\config\RegBack\
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
+        FileMask: SYSTEM
+    -
+        Name: SYSTEM registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows\System32\config\RegBack\
+        FileMask: SYSTEM1
+    -
+        Name: SYSTEM registry hive (RegBack)
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\RegBack\
         FileMask: SYSTEM1
     -
         Name: System Profile registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\systemprofile\
-        FileMask: ntuser.dat
+        Path: C:\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT
+    -
+        Name: System Profile registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT
     -
         Name: System Profile registry transaction files
         Category: Registry
-        Path: C:\Windows*\System32\config\systemprofile\
-        FileMask: ntuser.dat.LOG*
+        Path: C:\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT.LOG*
+    -
+        Name: System Profile registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\systemprofile\
+        FileMask: NTUSER.DAT.LOG*
     -
         Name: Local Service registry hive
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\LocalService\
-        FileMask: ntuser.dat
+        Path: C:\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT
+    -
+        Name: Local Service registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT
     -
         Name: Local Service registry transaction files
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\LocalService\
-        FileMask: ntuser.dat.LOG*
+        Path: C:\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT.LOG*
+    -
+        Name: Local Service registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\LocalService\
+        FileMask: NTUSER.DAT.LOG*
     -
         Name: Network Service registry hive
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\NetworkService\
-        FileMask: ntuser.dat
+        Path: C:\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT
+    -
+        Name: Network Service registry hive
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT
     -
         Name: Network Service registry transaction files
         Category: Registry
-        Path: C:\Windows*\ServiceProfiles\NetworkService\
-        FileMask: ntuser.dat.LOG*
+        Path: C:\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT.LOG*
+    -
+        Name: Network Service registry transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\ServiceProfiles\NetworkService\
+        FileMask: NTUSER.DAT.LOG*
     -
         Name: System Restore Points Registry Hives (XP)
         Category: Registry
         Path: C:\System Volume Information\_restore*\RP*\snapshot\
         FileMask: _REGISTRY_*
+

--- a/Targets/Windows/RegistryHivesUser.tkape
+++ b/Targets/Windows/RegistryHivesUser.tkape
@@ -5,29 +5,39 @@ Id: 635fbfd3-4a47-45b5-aae4-0a1bb6545d08
 RecreateDirectories: True
 Targets:
     -
-        Name: ntuser.dat registry hive XP
+        Name: NTUSER.DAT registry hive XP
         Category: Registry
         Path: C:\Documents and Settings\%user%\
-        FileMask: ntuser.dat
+        FileMask: NTUSER.DAT
     -
-        Name: ntuser.dat registry hive
+        Name: NTUSER.DAT registry hive
         Category: Registry
         Path: C:\Users\%user%\
-        FileMask: ntuser.dat
+        FileMask: NTUSER.DAT
     -
-        Name: ntuser.dat registry transaction files
+        Name: NTUSER.DAT registry transaction files
         Category: Registry
         Path: C:\Users\%user%\
-        FileMask: ntuser.dat.LOG*
+        FileMask: NTUSER.DAT.LOG*
     -
-        Name: ntuser.dat DEFAULT registry hive
+        Name: NTUSER.DAT DEFAULT registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows\System32\config\
         FileMask: DEFAULT
     -
-        Name: ntuser.dat DEFAULT transaction files
+        Name: NTUSER.DAT DEFAULT registry hive
         Category: Registry
-        Path: C:\Windows*\System32\config\
+        Path: C:\Windows.old\Windows\System32\config\
+        FileMask: DEFAULT
+    -
+        Name: NTUSER.DAT DEFAULT transaction files
+        Category: Registry
+        Path: C:\Windows\System32\config\
+        FileMask: DEFAULT.LOG*
+    -
+        Name: NTUSER.DAT DEFAULT transaction files
+        Category: Registry
+        Path: C:\Windows.old\Windows\System32\config\
         FileMask: DEFAULT.LOG*
     -
         Name: UsrClass.dat registry hive

--- a/Targets/Windows/SDB.tkape
+++ b/Targets/Windows/SDB.tkape
@@ -7,10 +7,20 @@ Targets:
     -
         Name: SDB Files 
         Category: Executables
-        Path: C:\Windows*\apppatch\Custom\
+        Path: C:\Windows\apppatch\Custom\
+        FileMask: '*.sdb'
+    -
+        Name: SDB Files 
+        Category: Executables
+        Path: C:\Windows.old\Windows\apppatch\Custom\
         FileMask: '*.sdb'
     -
         Name: SDB Files x64
         Category: Executables
-        Path: C:\Windows*\apppatch\Custom\Custom64\
+        Path: C:\Windows\apppatch\Custom\Custom64\
+        FileMask: '*.sdb'
+    -
+        Name: SDB Files x64
+        Category: Executables
+        Path: C:\Windows.old\Windows\apppatch\Custom\Custom64\
         FileMask: '*.sdb'

--- a/Targets/Windows/SRUM.tkape
+++ b/Targets/Windows/SRUM.tkape
@@ -7,6 +7,10 @@ Targets:
     -
         Name: SRUM
         Category: Execution
-        Path: C:\Windows*\System32\SRU\
+        Path: C:\Windows\System32\SRU\
         Recursive: True
-
+    -
+        Name: SRUM
+        Category: Execution
+        Path: C:\Windows.old\Windows\System32\SRU\
+        Recursive: True

--- a/Targets/Windows/ScheduledTasks.tkape
+++ b/Targets/Windows/ScheduledTasks.tkape
@@ -7,15 +7,30 @@ Targets:
     -
         Name: at .job
         Category: Persistence
-        Path: C:\Windows*\Tasks\
+        Path: C:\Windows\Tasks\
+        FileMask: '*.job'
+    -
+        Name: at .job
+        Category: Persistence
+        Path: C:\Windows.old\Windows\Tasks\
         FileMask: '*.job'
     -
         Name: at SchedLgU.txt
         Category: Persistence
-        Path: C:\Windows*\
+        Path: C:\Windows\
+        FileMask: SchedLgU.txt
+    -
+        Name: at SchedLgU.txt
+        Category: Persistence
+        Path: C:\Windows.old\Windows\
         FileMask: SchedLgU.txt
     -
         Name: XML
         Category: Persistence
-        Path: C:\Windows*\System32\Tasks\
+        Path: C:\Windows\System32\Tasks\
+        Recursive: True
+    -
+        Name: XML
+        Category: Persistence
+        Path: C:\Windows.old\Windows\System32\Tasks\
         Recursive: True

--- a/Targets/Windows/SignatureCatalog.tkape
+++ b/Targets/Windows/SignatureCatalog.tkape
@@ -7,10 +7,14 @@ Targets:
     -
         Name: SignatureCatalog
         Category: FileMetadata
-        Path: C:\Windows*\System32\CatRoot\
+        Path: C:\Windows\System32\CatRoot\
+        Recursive: True
+    -
+        Name: SignatureCatalog
+        Category: FileMetadata
+        Path: C:\Windows.old\Windows\System32\CatRoot\
         Recursive: True
 
-        
 ## USE CASE ##
 # Validating digital signatures of an offline system can be problematic.  
 # Microsoft relies mostly on detached signature files to sign Windows 

--- a/Targets/Windows/StartupInfo.tkape
+++ b/Targets/Windows/StartupInfo.tkape
@@ -7,5 +7,10 @@ Targets:
     -
         Name: StartupInfo XML Files
         Category: Persistence
-        Path: C:\Windows*\System32\WDI\LogFiles\StartupInfo\
+        Path: C:\Windows\System32\WDI\LogFiles\StartupInfo\
+        FileMask: '*.xml'
+    -
+        Name: StartupInfo XML Files
+        Category: Persistence
+        Path: C:\Windows.old\Windows\System32\WDI\LogFiles\StartupInfo\
         FileMask: '*.xml'

--- a/Targets/Windows/USBDevicesLogs.tkape
+++ b/Targets/Windows/USBDevicesLogs.tkape
@@ -12,5 +12,10 @@ Targets:
     -
         Name: Setupapi.log Win7+
         Category: USBDevices
-        Path: C:\Windows*\inf\
+        Path: C:\Windows\inf\
+        FileMask: setupapi.dev.log
+    -
+        Name: Setupapi.log Win7+
+        Category: USBDevices
+        Path: C:\Windows.old\Windows\inf\
         FileMask: setupapi.dev.log

--- a/Targets/Windows/WBEM.tkape
+++ b/Targets/Windows/WBEM.tkape
@@ -7,5 +7,10 @@ Targets:
     -
         Name: WBEM
         Category: WBEM
-        Path: C:\Windows*\System32\wbem\Repository\
+        Path: C:\Windows\System32\wbem\Repository\
+        Recursive: True
+    -
+        Name: WBEM
+        Category: WBEM
+        Path: C:\Windows.old\Windows\System32\wbem\Repository\
         Recursive: True

--- a/Targets/Windows/WER.tkape
+++ b/Targets/Windows/WER.tkape
@@ -17,5 +17,10 @@ Targets:
     -
         Name: Crash Dumps
         Category: SQL Exploitation
-        Path: C:\Windows*\
+        Path: C:\Windows\
+        FileMask: '*.dmp'
+    -
+        Name: Crash Dumps
+        Category: SQL Exploitation
+        Path: C:\Windows.old\Windows\
         FileMask: '*.dmp'

--- a/Targets/Windows/WindowsFirewall.tkape
+++ b/Targets/Windows/WindowsFirewall.tkape
@@ -7,5 +7,10 @@ Targets:
     -
         Name: Windows Firewall Logs
         Category: WindowsFirewallLogs
-        Path: C:\Windows*\System32\LogFiles\Firewall\
+        Path: C:\Windows\System32\LogFiles\Firewall\
+        FileMask: pfirewall.*
+    -
+        Name: Windows Firewall Logs
+        Category: WindowsFirewallLogs
+        Path: C:\Windows.old\Windows\System32\LogFiles\Firewall\
         FileMask: pfirewall.*


### PR DESCRIPTION
Thanks to Phill Moore for bringing this up!

## Description

Updated all Windows* targets to include one for .\Windows\ and one for .\Windows.old\Windows\. Other minor consistency changes. 

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my target(s)/module(s)
- [x] I have placed the target/module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
