### PR TITLE
Update Get-DoSvc4n6.mkape

### DIFF
--- a/Modules/LiveResponse/Get-DoSvc4n6.mkape
+++ b/Modules/LiveResponse/Get-DoSvc4n6.mkape
@@ -8,7 +8,7 @@ ExportFormat: CSV
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-DoSvc4n6.ps1' %sourceDirectory% -NoIP2Location -OutputPath %destinationDirectory%"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-DoSvc4n6.ps1' %sourceDirectory% -SkipIP2Location -OutputPath %destinationDirectory%"
         ExportFormat: CSV
 #####
 # Get-DoSvcExternalIP extracts public IP addresses of a Windows 10 device from DoSvc EventTraceLogs


### PR DESCRIPTION
Per LiveResponse Get-DoSvc4n6 command switch error #326

## Description

 LiveResponse Get-DoSvc4n6 command switch error #326 

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
