### PR TITLE
Freenet related Target and Module additions

### DIFF
--- a/Modules/Misc/hat-trick-freenet-parser.mkape
+++ b/Modules/Misc/hat-trick-freenet-parser.mkape
@@ -1,0 +1,21 @@
+Description: 'Hat-Trick: Freenet Parser'
+Category: Misc
+Author: Charlie Rubisoff
+Version: 1.0
+Id: 5c546be1-27f9-4739-86f6-e0391d1cc7db
+BinaryUrl: https://github.com/northloopforensics/Hat-Trick-Freenet-Parser/releases
+ExportFormat: txt
+Processors:
+    -
+        Executable: Hat-Trick.Freenet.Parser.exe
+        CommandLine: "%sourceDirectory% %destinationDirectory%"
+        ExportFormat: txt
+#####
+#Executable to parse Freenet installations using KAPE
+#
+#This program was written for use on Kroll's KAPE tool. Download the release and then copy the #executable to: kape\Modules\bin
+#
+#Also available in this repository are the Target profile (tkape) file and Module profile #(mkape) file. Copy these to the appropriate locations: kape\Targets\P2P\freenet.tkape & #kape\Modules\Misc\hat-trick-freenet-parser.mkape
+#
+#The tool parses: The Location ID and Network Addresses of the Target System Downloaded and #Uploaded File Information Peer IDs, Peer IP Addresses, and Peer-of-Peer Location IDs
+#####

--- a/Targets/P2P/Freenet.tkape
+++ b/Targets/P2P/Freenet.tkape
@@ -1,0 +1,31 @@
+Description: Freenet
+Author: Charlie Rubisoff
+Version: 1.0
+Id: dbf16082-0a99-4d3e-b24d-5fb20a1bd914
+RecreateDirectories: True
+Targets:
+    -
+        Name: Freenet
+        Category: File Downloads
+        Path: C:\Users\%user%\AppData\Local\Freenet\
+        FileMask: 'node*'
+    -
+        Name: Freenet
+        Category: File Downloads
+        Path: C:\Users\%user%\AppData\Local\Freenet\
+        FileMask: '*completed.list.downloads'
+    -
+        Name: Freenet
+        Category: File Downloads
+        Path: C:\Users\%user%\AppData\Local\Freenet\
+        FileMask: '*completed.list.uploads'
+    -
+        Name: Freenet
+        Category: File Downloads
+        Path: C:\Users\%user%\AppData\Local\Freenet\
+        FileMask: '*.bak'
+    -
+        Name: Freenet
+        Category: File Downloads
+        Path: C:\Users\%user%\AppData\Local\Freenet\downloads\
+        Recursive: True


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x ] I have generated a unique GUID for my Target(s)/Module(s)
- [x ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
