### PR TITLE
Update ScreenConnect.tkape

### DIFF
--- a/Targets/Apps/ScreenConnect.tkape
+++ b/Targets/Apps/ScreenConnect.tkape
@@ -21,6 +21,12 @@ Targets:
         Category: EventLogs
         Path: ApplicationEvents.tkape
         Comment: "Contains ScreenConnect entries, source: ScreenConnect Client"
-
+   -
+        Name: ScreenConnect User Config
+        Category: ApplicationLogs
+        Path: C:\ProgramData\ScreenConnect Client*\
+        FileMask: user.config
+        Comment: "Contains server domain and IP info"
+        
 # Documentation
 # N/A


### PR DESCRIPTION
Added target for user.config file

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
