### PR TITLE
Add KAPE Target/Compound Target guide/templates

### DIFF
--- a/Targets/CompundTargetGuide.guide
+++ b/Targets/CompundTargetGuide.guide
@@ -1,0 +1,39 @@
+#  Full documentation on Targets can be found here - https://ericzimmerman.github.io/KapeDocs/#!Pages\2.1-Targets.md. This guide is meant to provide a high level summary with the benefit of a template as a visual. 
+Description: Name of application/artifact here # Required, this will be visible within gKape on the Target side under the Description colum., 
+Author: Your name here # Required
+Version: 1.0 # Required, increment as revisions are made.
+Id: Unique GUID here # Required, generate within gKape by double clicking on a Target or Module, then click Generate GUID button at bottom of popup window, paste GUID here.
+RecreateDirectories: True # Required, true means the folder structure of the artifacts will be created within the user-specified Target Destination directory. If an artifact is buried 10 folders deep on the suspect's system, it will be buried 10 folders deep within the Target Destination folder.
+Targets:
+    -
+        Name: CompoundTarget1 # Required
+        Category: Category # Required, it is recommended to use the Category referenced within the Target file itself to keep things consistent.
+        Path: CompoundTarget1.tkape # Required, needs to exactly match the filename of the Target you're referencing, regardless of where the Target resides. KAPE will find it as long as it exists within the Targets folder.
+        Comments: "Comments go here" # Optional, and rarely used in Compound Targets, this won't be included in examples below.
+    -
+        Name: CompoundTarget2
+        Category: Category
+        Path: CompoundTarget2.tkape
+    -
+        Name: CompoundTarget3
+        Category: Category
+        Path: CompoundTarget1.tkape
+    -
+        Name: CompoundTarget4
+        Category: Category
+        Path: CompoundTarget2.tkape
+    -
+        Name: CompoundTarget5
+        Category: Category
+        Path: CompoundTarget1.tkape
+    -
+        Name: CompoundTarget6
+        Category: Category
+        Path: CompoundTarget2.tkape
+
+# Documentation
+# Include any and all documentation for your artifact, if any. If none, please include N/A instead. N/A is standard among all Targets without any documentation present and it makes it easy for one to search across all Targets that need documentation to be added.
+# Add more Targets as needed. 
+# Be sure to follow the steps within the Pull Request template to ensure there are no syntax errors prior to doing to Pull Request!
+# If there are any questions, just make an Issue on the KapeFiles repository and we'll get it figured out.
+# Please end all Targets with a blank new line below your last # line under Documentation. AKA hit enter once and save prior to doing a PR.

--- a/Targets/CompundTargetTemplate.template
+++ b/Targets/CompundTargetTemplate.template
@@ -1,0 +1,34 @@
+Description: Name of application/artifact here # Required
+Author: Your name here # Required
+Version: 1.0 # Required
+Id: Unique GUID here # Required
+RecreateDirectories: True # Required
+Targets:
+    -
+        Name: CompoundTarget1 # Required
+        Category: Category # Required
+        Path: CompoundTarget1.tkape # Required
+        Comments: "Comments go here" # Optional
+    -
+        Name: CompoundTarget2
+        Category: Category
+        Path: CompoundTarget2.tkape
+    -
+        Name: CompoundTarget3
+        Category: Category
+        Path: CompoundTarget1.tkape
+    -
+        Name: CompoundTarget4
+        Category: Category
+        Path: CompoundTarget2.tkape
+    -
+        Name: CompoundTarget5
+        Category: Category
+        Path: CompoundTarget1.tkape
+    -
+        Name: CompoundTarget6
+        Category: Category
+        Path: CompoundTarget2.tkape
+
+# Documentation
+# Please delete all Required/Optional comments above. N/A if no Documentation present. End with new line.

--- a/Targets/TargetGuide.guide
+++ b/Targets/TargetGuide.guide
@@ -1,0 +1,26 @@
+# Full documentation on Targets can be found here - https://ericzimmerman.github.io/KapeDocs/#!Pages\2.1-Targets.md. This guide is meant to provide a high level summary with the benefit of a template as a visual. 
+Description: Name of application/artifact here # Required, this will be visible within gKape on the Target side under the Description column.
+Author: Your name here # Required
+Version: 1.0 # Required, increment as Target is revised.
+Id: Unique GUID here # Required, generate within gKape by double clicking on a Target or Module, then click Generate GUID button at bottom of popup window, paste GUID here.
+RecreateDirectories: True # Required, true means the folder structure of the artifacts will be created within the user-specified Target Destination directory. If an artifact is buried 10 folders deep on the suspect's system, it will be buried 10 folders deep within the Target Destination folder.
+Targets:
+    -
+        Name: Artifact name here # Required
+        Category: Category goes here # Required, if your Target is related to other pre-existing Targets, it's recommended to use that same Category for your Target.
+        Path: C:\Users\%user%\AppData\*\Microsoft\ # Required, notice the %user% variable is in place telling KAPE to search every user folder on the system. * can be used as wildcards for folder or file names that are unpredictable/unique. 
+        Recursive: True # Optional, if missing, it will default to false.
+        FileMask: "desktop.ini" # Optional, other examples include SOFTWARE.logX (for those .log1, .log2, etc files), *_logs.txt (for those logs that are prepended with a timestamp, for instance), log*.txt (for log files that are named as log1, log2, etc), *.txt (for all .txt files regardless of filename), and filename.* (for all files with a filename of "filename", regardless of file extension) to name a few. When in doubt, test your Target on your own sample data to confirm it works.
+        AlwaysAddToQueue: True # Optional, this setting it mostly used for files that are actively in use by the system at the time of acquisition, i.e. MFT, etc. True means it'll defer grabbing the file until the other Targets run. In most cases, do not use this. Please read the KapeDocs documentation prior to using this.
+        SaveAsFileName: output.csv # Optional, but can be used if needed.
+        MinSize: 1000 # Optional, in bytes.
+        MaxSize: 10000 # Optional, in bytes.
+        Comment: "Locates all evidence to solve the case" # Optional, but it helps to give a brief overview of what is grabbed. Go into more detail in the Documentation section below.
+
+# Documentation
+# https://ericzimmerman.github.io/KapeDocs/#!Pages\2.1-Targets.md
+# Include any and all documentation for your artifact, if any. If none, please include N/A instead. N/A is standard among all Targets without any documentation present and it makes it easy for one to search across all Targets that need documentation to be added.
+# Add more Targets as needed. 
+# Be sure to follow the steps within the Pull Request template to ensure there are no syntax errors prior to doing to Pull Request!
+# If there are any questions, just make an Issue on the KapeFiles repository and we'll get it figured out.
+# Please end all Targets with a blank new line below your last # line under Documentation. AKA hit enter once and save prior to doing a PR.

--- a/Targets/TargetTemplate.template
+++ b/Targets/TargetTemplate.template
@@ -1,0 +1,20 @@
+Description: Name of application/artifact here # Required
+Author: Your name here # Required
+Version: 1.0 # Required
+Id: Unique GUID here # Required
+RecreateDirectories: True # Required
+Targets:
+    -
+        Name: Artifact name here # Required
+        Category: Category goes here # Required
+        Path: C:\ # Required
+        Recursive: True # Optional
+        FileMask: "filename.ext" # Optional
+        AlwaysAddToQueue: True # Optional
+        SaveAsFileName: output.csv # Optional
+        MinSize: 1000 # Optional
+        MaxSize: 10000 # Optional
+        Comment: "Locates all evidence to solve the case" # Optional
+
+# Documentation
+# Please delete all Required/Optional comments above and replace this line(s) with any link(s) to relevant blog posts, YouTube videos, etc. Add more lines as needed.

--- a/Targets/Windows/SRUM.tkape
+++ b/Targets/Windows/SRUM.tkape
@@ -41,4 +41,3 @@ Targets:
 # https://www.youtube.com/watch?v=l6-83WU95Sw
 # https://www.youtube.com/watch?v=Uw8n4_o-ETM
 # https://digital-forensics.sans.org/summit-archives/file/summit_archive_1492184583.pdf
-

--- a/Targets/Windows/WindowsYourPhone.tkape
+++ b/Targets/Windows/WindowsYourPhone.tkape
@@ -9,7 +9,7 @@ Targets:
         Category: Apps
         Path: C:\Users\%user%\AppData\Local\Packages\Microsoft.YourPhone_8wekyb3d8bbwe\LocalCache\Indexed
         Recursive: True
-        Comment: "Locates all Your Phone database files "
+        Comment: "Locates all Your Phone database files"
 
 # Documentation
 # This has only been tested with Android at this time. I don't own an Apple device but if someone else does, feel free to edit this target file with iOS related information. 


### PR DESCRIPTION
## Description

Add KAPE Target/Compound Target guide/templates. Minor fix.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
