### PR TITLE
Added OpenSSH target

### DIFF
--- a/Targets/Apps/OpenSSH.tkape
+++ b/Targets/Apps/OpenSSH.tkape
@@ -1,0 +1,33 @@
+Description: OpenSSH Config, known hosts and keys
+Author: Matt Dawson
+Version: 1.0
+Id: 77f56ec6-61ae-450f-b90e-ac60352093ef
+RecreateDirectories: True
+Targets:
+    -
+        Name: OpenSSH Config File
+        Category: Apps
+        Path: C:\Users\%user%\.ssh\
+        FileMask: 'config'
+        Comment: "Config file can hold usernames, IP addresses and ports, key locations and configured shortcuts for servers e.g. ssh web-server"
+    -
+        Name: OpenSSH Known Hosts
+        Category: Apps
+        Path: C:\Users\%user%\.ssh\
+        FileMask: 'known_hosts'
+        Comment: "Known hosts file can hold a list of connected FQDNs/IP Addresses and ports if they are non-default, as well as public key fingerprints"
+    -
+        Name: OpenSSH Public Keys
+        Category: Apps
+        Path: C:\Users\%user%\.ssh\
+        FileMask: '*.pub'
+        Comment: "Gets all public keys (*.pub). It is more difficult to find private keys as they typically do not have a file extension. However, the .pub files should be able to help find the private keys as they are typically named the same."
+    -
+        Name: OpenSSH Default Private Key
+        Category: Apps
+        Path: C:\Users\%user%\.ssh\
+        FileMask: 'id_rsa'
+        Comment: "Default name for an auto-generated SSH private key"
+
+# Documentation
+# N/A


### PR DESCRIPTION
## Description

Added OpenSSH.tkape for the following files:

- config - this file can hold usernames, IP addresses and ports, key locations and configured shortcuts for servers
- known_hosts - can hold a list of connected FQDNs/IP Addresses and ports if they are non-default, as well as key fingerprints
- *.pub - all public keys (this can help identify the names of private keys)
- id_rsa - the autogenerated private key

## Checklist:

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
