### PR TITLE
Add Media History to Edge Chromium Target

### DIFF
--- a/Targets/Browsers/EdgeChromium.tkape
+++ b/Targets/Browsers/EdgeChromium.tkape
@@ -55,6 +55,11 @@ Targets:
         Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
         FileMask: Login Data
     -
+        Name: Edge Media History
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\
+        FileMask: Media History*
+    -
         Name: Edge Network Action Predictor
         Category: Communications
         Path: C:\Users\%user%\AppData\Local\Microsoft\Edge\User Data\*\


### PR DESCRIPTION
## Description

Adds Media History database as part of the Edge Chromium collection Target

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have generated a unique GUID for my Target(s)/Module(s)
- [X] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
