### PR TITLE
Add KapeResearch Modules for RECmd/EVTXECmd

### DIFF
--- a/Modules/KapeResearch/KapeResearch_EventLogs.mkape
+++ b/Modules/KapeResearch/KapeResearch_EventLogs.mkape
@@ -1,0 +1,20 @@
+Description: 'EvtxECmd: Convert log files to XML for research'
+Category: KapeResearch
+Author: Andrew Rathbun
+Version: 1.0
+Id: 09b93d8e-c417-4e79-aaef-a2af3f46fd08
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
+ExportFormat: xml
+Processors:
+    -
+        Executable: EvtxECmd\EvtxECmd.exe
+        CommandLine: -d %sourceDirectory% --xml %destinationDirectory%
+        ExportFormat: xml
+
+# Documentation
+# https://github.com/EricZimmerman/evtx
+# https://binaryforay.blogspot.com/2019/04/introducing-evtxecmd.html
+# https://www.youtube.com/watch?v=YvMg3p7O6ro
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Be sure to run evtxecmd.exe --sync within your .\KAPE\Modules\bin\EvtxECmd directory to ensure you have the latest maps!
+# This module will convert any Event Logs into XML, which is helpful for viewing all of the data stored within the various Event Logs on a system

--- a/Modules/KapeResearch/KapeResearch_Registry_NTUSER.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_NTUSER.mkape
@@ -1,0 +1,25 @@
+Description: 'RECmd: Convert NTUSER.dat registry hive to JSON for research'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: 64903403-bbf0-4bb5-bec0-023753f273d3
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: json
+FileMask: NTUSER.dat
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: -d %sourceDirectory% --kn ROOT --nl false --json %destinationDirectory% -q
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
+# This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way
+# You will want to rename the hive to NTUSER_ROOT.json or similar. If you run all of the KapeResearch Modules at the same time, they will write over each other and you'll only end up with a single ROOT.json file

--- a/Modules/KapeResearch/KapeResearch_Registry_SAM.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_SAM.mkape
@@ -1,0 +1,25 @@
+Description: 'RECmd: Convert SAM registry hive to JSON for research'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: 8bf99655-d244-42dd-bbef-43d089cd1f1a
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: json
+FileMask: SAM
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: -d %sourceDirectory% --kn ROOT --nl false --json %destinationDirectory% -q
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
+# This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way
+# You will want to rename the hive to SAM_ROOT.json or similar. If you run all of the KapeResearch Modules at the same time, they will write over each other and you'll only end up with a single ROOT.json file

--- a/Modules/KapeResearch/KapeResearch_Registry_SECURITY.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_SECURITY.mkape
@@ -1,0 +1,25 @@
+Description: 'RECmd: Convert SECURITY registry hive to JSON for research'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: 2ef7dd84-58b7-4d17-a5e8-fd39cda3be4b
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: json
+FileMask: SECURITY
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: -d %sourceDirectory% --kn ROOT --nl false --json %destinationDirectory% -q
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
+# This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way
+# You will want to rename the hive to SECURITY_ROOT.json or similar. If you run all of the KapeResearch Modules at the same time, they will write over each other and you'll only end up with a single ROOT.json file

--- a/Modules/KapeResearch/KapeResearch_Registry_SOFTWARE.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_SOFTWARE.mkape
@@ -1,0 +1,25 @@
+Description: 'RECmd: Convert SOFTWARE registry hive to JSON for research'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: 89b05524-78a1-428f-8b46-4de445df8716
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: json
+FileMask: SOFTWARE
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: -d %sourceDirectory% --kn ROOT --nl false --json %destinationDirectory% -q
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
+# This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way
+# You will want to rename the hive to SOFTWARE_ROOT.json or similar. If you run all of the KapeResearch Modules at the same time, they will write over each other and you'll only end up with a single ROOT.json file

--- a/Modules/KapeResearch/KapeResearch_Registry_SYSTEM.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_SYSTEM.mkape
@@ -1,0 +1,25 @@
+Description: 'RECmd: Convert SYSTEM registry hive to JSON for research'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: 97f567c7-4f9e-4136-a488-630838daf37a
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: json
+FileMask: SYSTEM
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: -d %sourceDirectory% --kn ROOT --nl false --json %destinationDirectory% -q
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
+# This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way
+# You will want to rename the hive to SYSTEM_ROOT.json or similar. If you run all of the KapeResearch Modules at the same time, they will write over each other and you'll only end up with a single ROOT.json file

--- a/Modules/KapeResearch/KapeResearch_Registry_UsrClass.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_UsrClass.mkape
@@ -1,0 +1,26 @@
+Description: 'RECmd: Convert UsrClass.dat registry hive to JSON for research'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: 47442088-63d1-4f1d-9c7c-3ef47d100a13
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: json
+FileMask: UsrClass.dat
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: -d %sourceDirectory% --kn ROOT --nl false --json %destinationDirectory% -q
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
+# This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way
+# You will want to rename the hive to UsrClass_ROOT.json or similar. If you run all of the KapeResearch Modules at the same time, they will write over each other and you'll only end up with a single ROOT.json file
+# UsrClass.dat will have to be done manually. Open the UsrClass.dat in Registry Explorer and use the name of the ROOT key and run this same command with that value in place of ROOT


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
