### PR TITLE
Add compound to USB device logs section

### DIFF
--- a/Targets/Compound/!SANS_Triage.tkape
+++ b/Targets/Compound/!SANS_Triage.tkape
@@ -495,7 +495,7 @@ Targets:
         Path: C:\Users\%user%\AppData\Local\Microsoft\Windows\Explorer\
         FileMask: thumbcache_*.db
 
-# USB Devices Logs
+# USB Devices Logs - .\Targets\Windows\USBDevicesLogs.tkape
     -
         Name: Setupapi.log XP
         Category: USBDevices


### PR DESCRIPTION
## Description

Only added the link to the compound in the USB device logs section.