### PR TITLE
Add NetSystemInfo_Use to official module LR folder

### DIFF
--- a/Modules/LiveResponse/NetSystemInfo_Use.mkape
+++ b/Modules/LiveResponse/NetSystemInfo_Use.mkape
@@ -1,0 +1,13 @@
+Description: Gathers Basic System Information Using the Net Command (Use)
+Category: LiveResponse
+Author: piesecurity
+Version: 1.0
+Id: 979b4a71-abf8-4f0b-9b94-51e9c1384888
+ExportFormat: txt 
+Processors:
+    -
+        Executable: C:\Windows\System32\net.exe
+        CommandLine: Use
+        ExportFormat: txt
+        ExportFile: NetSystemInfo.txt
+        Append: True


### PR DESCRIPTION
Move the NetSystemInfo_Use module file to the LR folder. This file is currently missing in the main Github repo and is only available via "!Local" folder inside the Kape download archive. However, the combound for NetSystemInfo does include that file.