### PR TITLE
Fix wrong status command line param for manage-bde module

### DIFF
--- a/Modules/LiveResponse/manage-bde.mkape
+++ b/Modules/LiveResponse/manage-bde.mkape
@@ -1,13 +1,13 @@
 Description: Check for BitLocker volumes
 Category: VolumeInformation
 Author: troyla@microsoft.com
-Version: 1.0
+Version: 1.1
 Id: b069705b-13f0-42c7-86a2-4f310c3c651b
 ExportFormat: txt
 Processors:
     -
         Executable: C:\Windows\System32\manage-bde.exe
-        CommandLine: -status %sourceDirectory%
+        CommandLine: -status %sourceDriveLetter%
         ExportFormat: txt
         ExportFile: BitLocker-Status.txt
 


### PR DESCRIPTION
## Description

Replace sourceDirectory with sourceDriveLetter according to the manage-bde documentation and my testing:
* manage-bde.exe -status C: runs successfully
* but running manage-bde.exe -status C:\ fails.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
