### PR TITLE
Fix RegTime binary location in documentation

### DIFF
--- a/Modules/timelining/RegTime_Default_TLN.mkape
+++ b/Modules/timelining/RegTime_Default_TLN.mkape
@@ -16,4 +16,4 @@ Processors:
         
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the bin folder with regtime.exe
+# Place "p2x5124.dll" and regtime.exe in the Modules\bin\tln_tools folder

--- a/Modules/timelining/RegTime_NTUSER_TLN.mkape
+++ b/Modules/timelining/RegTime_NTUSER_TLN.mkape
@@ -16,4 +16,4 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the \Modules\bin folder with regtime.exe
+# Place "p2x5124.dll" and regtime.exe in the Modules\bin\tln_tools folder

--- a/Modules/timelining/RegTime_SAM_TLN.mkape
+++ b/Modules/timelining/RegTime_SAM_TLN.mkape
@@ -15,5 +15,5 @@ Processors:
         Append: True
 
 # Documentation
-# https://github.com/keydet89/Tools/tree/master/exe 
-# Place "p2x5124.dll" in the bin folder with regtime.exe        
+# https://github.com/keydet89/Tools/tree/master/exe
+# Place "p2x5124.dll" and regtime.exe in the Modules\bin\tln_tools folder

--- a/Modules/timelining/RegTime_Security_TLN.mkape
+++ b/Modules/timelining/RegTime_Security_TLN.mkape
@@ -16,4 +16,4 @@ Processors:
         
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe 
-# Place "p2x5124.dll" in the bin folder with regtime.exe
+# Place "p2x5124.dll" and regtime.exe in the Modules\bin\tln_tools folder

--- a/Modules/timelining/RegTime_Software_TLN.mkape
+++ b/Modules/timelining/RegTime_Software_TLN.mkape
@@ -15,5 +15,5 @@ Processors:
         Append: True
 
 # Documentation
-# https://github.com/keydet89/Tools/tree/master/exe 
-# Place "p2x5124.dll" in the bin folder with regtime.exe
+# https://github.com/keydet89/Tools/tree/master/exe
+# Place "p2x5124.dll" and regtime.exe in the Modules\bin\tln_tools folder

--- a/Modules/timelining/RegTime_System_TLN.mkape
+++ b/Modules/timelining/RegTime_System_TLN.mkape
@@ -15,5 +15,5 @@ Processors:
         Append: True
         
 # Documentation
-# https://github.com/keydet89/Tools/tree/master/exe 
-# Place "p2x5124.dll" in the bin folder with regtime.exe
+# https://github.com/keydet89/Tools/tree/master/exe
+# Place "p2x5124.dll" and regtime.exe in the Modules\bin\tln_tools folder

--- a/Modules/timelining/RegTime_UsrClass_TLN.mkape
+++ b/Modules/timelining/RegTime_UsrClass_TLN.mkape
@@ -16,4 +16,4 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the \Modules\bin folder with regtime.exe
+# Place "p2x5124.dll" and regtime.exe in the Modules\bin\tln_tools folder


### PR DESCRIPTION
Add the required folder tln_tools in the documentation section for regtime.exe.