### PR TITLE
Improve documenation regarding computerName placeholder

### DIFF
--- a/Modules/timelining/EVT_Application_TLN.mkape
+++ b/Modules/timelining/EVT_Application_TLN.mkape
@@ -14,6 +14,7 @@ Processors:
         ExportFile: temp.tln
         Append: True
 
-# Documentation                                             
+# Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the bin folder with evtparse.exe
+# Place "p2x5124.dll" in the Modules/bin/tln_tools folder with evtparse.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/EVT_Security_TLN.mkape
+++ b/Modules/timelining/EVT_Security_TLN.mkape
@@ -16,4 +16,5 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the bin folder with evtparse.exe
+# Place "p2x5124.dll" in the Modules/bin/tln_tools folder with evtparse.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/EVT_System_TLN.mkape
+++ b/Modules/timelining/EVT_System_TLN.mkape
@@ -13,7 +13,8 @@ Processors:
         ExportFormat: csv
         ExportFile: temp.tln
         Append: True
-        
+
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the bin folder with evtparse.exe
+# Place "p2x5124.dll" in the Modules/bin/tln_tools folder with evtparse.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/MFTECmd_$MFT_TLN.mkape
+++ b/Modules/timelining/MFTECmd_$MFT_TLN.mkape
@@ -15,6 +15,10 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
+# Place bodyfile.exe in Modules/bin/tln_tools
+# Add in key "computerName" using --mvars computerName:XXXX
+# 
+# The MFTECmd_$MFT_Bodyfile.mkape must be ran before this to create the bodyfile. This module with then convert the bodyfile into TLN format
+#
 # https://www.sans.org/blog/triage-collection-and-timeline-generation-with-kape/
 # https://www.youtube.com/watch?v=GhCZfCzn2l0
-# The MFTECmd_$MFT_Bodyfile.mkape must be ran before this to create the bodyfile. This module with then convert the bodyfile into TLN format

--- a/Modules/timelining/Mini_Timeline.mkape
+++ b/Modules/timelining/Mini_Timeline.mkape
@@ -1,4 +1,4 @@
-Description: Parses MFT, Registy and Event Logs into mini-timeline; Add in key "computerName" 
+Description: Parses MFT, Registy and Event Logs into mini-timeline
 Category: Timeline
 Author: Mari DeGrazia
 Version: 1.0
@@ -58,11 +58,11 @@ Processors:
         Executable: RegTime_System_TLN.mkape
         CommandLine: ""
         ExportFormat: ""
-    -       
+    -
         Executable: RegRipper_Services_TLN.mkape
         CommandLine: ""
         ExportFormat: ""
-    -       
+    -
         Executable: RegTime_Default_TLN.mkape
         CommandLine: ""
         ExportFormat: ""
@@ -78,7 +78,7 @@ Processors:
         Executable: RegRipper_NTUSER_userassit_TLN.mkape
         CommandLine: ""
         ExportFormat: ""
-        
+
 ##Add new modules for TLN output above this line^
     -
         Executable: Convert_unicode.mkape
@@ -88,3 +88,6 @@ Processors:
         Executable: Parse_TLN.mkape
         CommandLine: ""
         ExportFormat: ""
+
+# Documentation
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegRipper_AppCompatCache_TLN.mkape
+++ b/Modules/timelining/RegRipper_AppCompatCache_TLN.mkape
@@ -18,3 +18,4 @@ Processors:
 # https://github.com/keydet89/RegRipper3.0
 # Create a folder "regripper" within the "Modules\bin" KAPE folder
 # Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegRipper_NTUSER_muicache_TLN.mkape
+++ b/Modules/timelining/RegRipper_NTUSER_muicache_TLN.mkape
@@ -18,3 +18,4 @@ Processors:
 # https://github.com/keydet89/RegRipper3.0
 # Create a folder "regripper" within the "Modules\bin" KAPE folder
 # Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegRipper_NTUSER_userassit_TLN.mkape
+++ b/Modules/timelining/RegRipper_NTUSER_userassit_TLN.mkape
@@ -18,3 +18,4 @@ Processors:
 # https://github.com/keydet89/RegRipper3.0
 # Create a folder "regripper" within the "Modules\bin" KAPE folder
 # Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegRipper_Services_TLN.mkape
+++ b/Modules/timelining/RegRipper_Services_TLN.mkape
@@ -18,3 +18,4 @@ Processors:
 # https://github.com/keydet89/RegRipper3.0
 # Create a folder "regripper" within the "Modules\bin" KAPE folder
 # Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegTime_Default_TLN.mkape
+++ b/Modules/timelining/RegTime_Default_TLN.mkape
@@ -16,4 +16,5 @@ Processors:
         
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the bin folder with regtime.exe
+# Place "p2x5124.dll" in the Modules/bin/tln_tools folder with regtime.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegTime_NTUSER_TLN.mkape
+++ b/Modules/timelining/RegTime_NTUSER_TLN.mkape
@@ -16,4 +16,5 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the \Modules\bin folder with regtime.exe
+# Place "p2x5124.dll" in the Modules\bin\tln_tools folder with regtime.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegTime_SAM_TLN.mkape
+++ b/Modules/timelining/RegTime_SAM_TLN.mkape
@@ -16,4 +16,5 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe 
-# Place "p2x5124.dll" in the bin folder with regtime.exe        
+# Place "p2x5124.dll" in the Modules/bin/tln_tools folder with regtime.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegTime_Security_TLN.mkape
+++ b/Modules/timelining/RegTime_Security_TLN.mkape
@@ -17,3 +17,4 @@ Processors:
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe 
 # Place "p2x5124.dll" in the bin folder with regtime.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegTime_Software_TLN.mkape
+++ b/Modules/timelining/RegTime_Software_TLN.mkape
@@ -16,4 +16,5 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe 
-# Place "p2x5124.dll" in the bin folder with regtime.exe
+# Place "p2x5124.dll" in the Modules/bin/tln_tools folder with regtime.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegTime_System_TLN.mkape
+++ b/Modules/timelining/RegTime_System_TLN.mkape
@@ -16,4 +16,5 @@ Processors:
         
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe 
-# Place "p2x5124.dll" in the bin folder with regtime.exe
+# Place "p2x5124.dll" in the Modules/bin/tln_tools folder with regtime.exe
+# Add in key "computerName" using --mvars computerName:XXXX

--- a/Modules/timelining/RegTime_UsrClass_TLN.mkape
+++ b/Modules/timelining/RegTime_UsrClass_TLN.mkape
@@ -16,4 +16,5 @@ Processors:
 
 # Documentation
 # https://github.com/keydet89/Tools/tree/master/exe
-# Place "p2x5124.dll" in the \Modules\bin folder with regtime.exe
+# Place "p2x5124.dll" in the \Modules\bin\tln_tools folder with regtime.exe
+# Add in key "computerName" using --mvars computerName:XXXX


### PR DESCRIPTION
Add --mvars example to documentation section in various timelining modules and add tln_tools to path info in documentation section.

See #367 because without the info it's unclear if it's the shell variable or a user supplied key.