### PR TITLE
Fix MD5 column name in processlist module output

### DIFF
--- a/Modules/LiveResponse/PWSH-Get-CimInstance_ProcessList.mkape
+++ b/Modules/LiveResponse/PWSH-Get-CimInstance_ProcessList.mkape
@@ -1,17 +1,17 @@
 Description: Display running processes and context information 
 Category: LiveResponse
-Author: Markus Neis, Swisscom 
+Author: Markus Neis, Swisscom
 Version: 1.0
 Id: f5afb643-3a77-4e3e-a028-18cbeaf5c406
-ExportFormat: csv 
+ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine:  -Command "Get-CimInstance Win32_Process | select ProcessId, ProcessName, Path, CommandLine, Description, ParentProcessId , CreationDate, Handle, HandleCount, @{Label='File Path MD-5'; Expression={(Get-FileHash -Algorithm MD5 -LiteralPath $_.Path).Hash}} | Export-Csv -NoTypeInformation -Path %destinationDirectory%\PWSH-Get-CIM_ProcessList.csv"
+        CommandLine:  -Command "Get-CimInstance Win32_Process | select ProcessId, ProcessName, Path, CommandLine, Description, ParentProcessId , CreationDate, Handle, HandleCount, @{Label='MD5'; Expression={(Get-FileHash -Algorithm MD5 -LiteralPath $_.Path).Hash}} | Export-Csv -NoTypeInformation -Path %destinationDirectory%\PWSH-Get-CIM_ProcessList.csv"
         ExportFormat: csv
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "Get-CimInstance Win32_Process | select ProcessId, ProcessName, Path, CommandLine, Description, ParentProcessId , CreationDate, Handle, HandleCount, @{Label='File Path MD-5'; Expression={(Get-FileHash -Algorithm MD5 -LiteralPath $_.Path).Hash}} |  ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\PWSH-Get-CIM_ProcessList.json"              
+        CommandLine: -Command "Get-CimInstance Win32_Process | select ProcessId, ProcessName, Path, CommandLine, Description, ParentProcessId , CreationDate, Handle, HandleCount, @{Label='MD5'; Expression={(Get-FileHash -Algorithm MD5 -LiteralPath $_.Path).Hash}} |  ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\PWSH-Get-CIM_ProcessList.json"
         ExportFormat: json
 
 # Documentation


### PR DESCRIPTION
Only replace MD-5 with MD5 and remove unneeded "File Path" in column name in the CIM process list module output. Additionally, I removed some trailing spaces.