### PR TITLE
Minor updates

### DIFF
--- a/Modules/BrowsingHistory/BrowsingHistoryView.mkape
+++ b/Modules/BrowsingHistory/BrowsingHistoryView.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory% /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
         ExportFormat: csv
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory% /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
         ExportFormat: html
 
 # Documentation

--- a/Targets/Windows/WindowsYourPhone.tkape
+++ b/Targets/Windows/WindowsYourPhone.tkape
@@ -12,6 +12,7 @@ Targets:
         Comment: "Locates all Your Phone database files"
 
 # Documentation
+# https://iconline.ipleiria.pt/bitstream/10400.8/4179/1/Digital_forensic_artifacts_YourPhone_W10.pdf
 # This has only been tested with Android at this time. I don't own an Apple device but if someone else does, feel free to edit this target file with iOS related information.
 # This target will recursively grab folders with a complete file path similar to this one: .\AppData\Local\Packages\Microsoft.YourPhone_8wekyb3d8bbwe\LocalCache\Indexed\GUID\System\Database\.
 # Inside this directory on my system were the following files


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors. 
