### PR TITLE
Fix RegRipper download URL to align with the current version

### DIFF
--- a/Modules/Registry/RegRipper-ALL.mkape
+++ b/Modules/Registry/RegRipper-ALL.mkape
@@ -3,7 +3,7 @@ Category: Registry
 Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
 Version: 1.0
 Id: 76037ee9-0346-459a-a44a-1b67edc711c8
-BinaryUrl: https://github.com/keydet89/RegRipper2.8
+BinaryUrl: https://github.com/keydet89/RegRipper3.0
 ExportFormat: txt
 FileMask: ""
 Processors:

--- a/Modules/Registry/RegRipper-ntuser.mkape
+++ b/Modules/Registry/RegRipper-ntuser.mkape
@@ -3,7 +3,7 @@ Category: Registry
 Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
 Version: 1.1
 Id: ce3bf979-0d4d-4a31-8240-6be6f95610b7
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: ntuser.dat
 Processors:

--- a/Modules/Registry/RegRipper-sam.mkape
+++ b/Modules/Registry/RegRipper-sam.mkape
@@ -3,7 +3,7 @@ Category: Registry
 Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
 Version: 1.1
 Id: 4b1babd2-c7e1-4f1f-a34f-1968d3672752
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: SAM
 Processors:

--- a/Modules/Registry/RegRipper-security.mkape
+++ b/Modules/Registry/RegRipper-security.mkape
@@ -3,7 +3,7 @@ Category: Registry
 Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
 Version: 1.1
 Id: a0011605-10ac-4e7b-b422-8d1afeebfd5c
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: SECURITY
 Processors:

--- a/Modules/Registry/RegRipper-software.mkape
+++ b/Modules/Registry/RegRipper-software.mkape
@@ -3,7 +3,7 @@ Category: Registry
 Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
 Version: 1.1
 Id: 8fa920ff-03ce-4f88-af2a-0558187f708c
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: SOFTWARE
 Processors:

--- a/Modules/Registry/RegRipper-system.mkape
+++ b/Modules/Registry/RegRipper-system.mkape
@@ -3,7 +3,7 @@ Category: Registry
 Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
 Version: 1.1
 Id: ef988f41-7d77-436d-bc1a-1789f062506b
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: SYSTEM
 Processors:

--- a/Modules/timelining/RegRipper_AppCompatCache_TLN.mkape
+++ b/Modules/timelining/RegRipper_AppCompatCache_TLN.mkape
@@ -3,7 +3,7 @@ Category: Timeline
 Author: Mari DeGrazia
 Version: 1.0
 Id: 680dfc07-07af-48a8-9bda-06eab3136baf
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: SYSTEM
 Processors:

--- a/Modules/timelining/RegRipper_NTUSER_muicache_TLN.mkape
+++ b/Modules/timelining/RegRipper_NTUSER_muicache_TLN.mkape
@@ -3,7 +3,7 @@ Category: Timeline
 Author: Mari DeGrazia
 Version: 1.0
 Id: 0132fe8e-4887-40a3-a86e-fbffbfe29a10
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: ntuser.dat
 Processors:

--- a/Modules/timelining/RegRipper_NTUSER_userassit_TLN.mkape
+++ b/Modules/timelining/RegRipper_NTUSER_userassit_TLN.mkape
@@ -3,7 +3,7 @@ Category: Timeline
 Author: Mari DeGrazia
 Version: 1.0
 Id: c83be38c-a35f-414a-9349-daa4d8a11c72
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: ntuser.dat
 Processors:

--- a/Modules/timelining/RegRipper_Services_TLN.mkape
+++ b/Modules/timelining/RegRipper_Services_TLN.mkape
@@ -3,7 +3,7 @@ Category: Timeline
 Author: Mari DeGrazia
 Version: 1.0
 Id: 0b9786de-cd3f-48aa-82be-2c6547524f08
-BinaryUrl: https://github.com/keydet89/RegRipper2.8/archive/master.zip
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
 ExportFormat: txt
 FileMask: SYSTEM
 Processors:


### PR DESCRIPTION
Fix RegRipper download URL in all RR modules to align with the current version 3.0 and to match with the link in the documentation section.