### PR TITLE
Add WMI repository auditing module to live response

### DIFF
--- a/Modules/LiveResponse/WMI-Repository-Auditing.mkape
+++ b/Modules/LiveResponse/WMI-Repository-Auditing.mkape
@@ -1,0 +1,15 @@
+Description: Collect WMI repository information
+Category: LiveResponse
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: cebffd14-901a-44fd-9960-e3a781acc1d9
+ExportFormat: txt
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine:  -Command "write 'Event Filter'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __EventFilter; write ' '; write 'EventConsumer'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __EventConsumer; write ' '; write 'FilterToConsumerBinding'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __FilterToConsumerBinding"
+        ExportFormat: txt
+        ExportFile: wmi-repository-auditing.txt
+
+# Documentation
+# https://www.sans.org/blog/investigating-wmi-attacks/

--- a/Modules/LiveResponse/WMI-Repository-Auditing.mkape
+++ b/Modules/LiveResponse/WMI-Repository-Auditing.mkape
@@ -7,7 +7,7 @@ ExportFormat: txt
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine:  -Command "write 'Event Filter'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __EventFilter; write ' '; write 'EventConsumer'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __EventConsumer; write ' '; write 'FilterToConsumerBinding'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __FilterToConsumerBinding"
+        CommandLine: -Command "write 'Event Filter'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __EventFilter; write ' '; write 'EventConsumer'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __EventConsumer; write ' '; write 'FilterToConsumerBinding'; write ' '; Get-WMIObject -Namespace root\Subscription -Class __FilterToConsumerBinding"
         ExportFormat: txt
         ExportFile: wmi-repository-auditing.txt
 


### PR DESCRIPTION
## Description

Add live response module to collection WMI repository information. All three commands for getting EventFilter, EventConsumer and FilterToConsumerBinding are executed, see https://www.sans.org/blog/investigating-wmi-attacks/ as reference.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
