### PR TITLE
Rename hashes.mkape to ntlm-hashes and fix documentation

### DIFF
--- a/Modules/LiveResponse/ntlm-hashes.mkape
+++ b/Modules/LiveResponse/ntlm-hashes.mkape
@@ -14,7 +14,7 @@ Processors:
 # Documentation
 # https://github.com/gentilkiwi/mimikatz
 # https://www.varonis.com/blog/what-is-mimikatz/
-# This module (Hashes.mkape) extracts the Windows NTLM hashes for every user account. The command is a little bit dirty, but it works.
+# This module extracts the Windows NTLM hashes for every user account. The command is a little bit dirty, but it works.
 # Point the 'module source' to the acquired "\Windows\System32\config" folder
 # mimikatz.exe (x64) must be put in 'Modules\bin' folder
 # Attention: your antivirus may not appreciate the program; whitelist it.
@@ -22,4 +22,4 @@ Processors:
 # Remember: NTLM-hash 31d6cfe0d16ae931b73c59d7e0c089c0 means "blank"
 #
 # Example:
-# .\kape.exe --msource C:\kape\path\to\acquired\Windows\System32\config --mdest C:\kape\out --module Hashes
+# .\kape.exe --msource C:\kape\path\to\acquired\Windows\System32\config --mdest C:\kape\out --module ntlm-hashes


### PR DESCRIPTION
## Description

Rename hashes.mkape to the more informative ntlm-hashes.mkape to reflect the purpose of the module (NTLM hashes). Also rename it to distinguish for a future file hash module discussed in https://github.com/EricZimmerman/KapeFiles/pull/365.