### PR TITLE
Add RegRipper module for UsrClass.dat

### DIFF
--- a/Modules/Registry/RegRipper-ALL.mkape
+++ b/Modules/Registry/RegRipper-ALL.mkape
@@ -1,11 +1,10 @@
 Description: 'RegRipper: parse all supported hives'
 Category: Registry
-Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore
-Version: 1.0
+Author: ZeArioch <https://{github,twitter}.com/ZeArioch>, Phill Moore, Andreas Hunkeler (@Karneades)
+Version: 1.1
 Id: 76037ee9-0346-459a-a44a-1b67edc711c8
 BinaryUrl: https://github.com/keydet89/RegRipper3.0
 ExportFormat: txt
-FileMask: ""
 Processors:
     -
         Executable: RegRipper-sam.mkape
@@ -25,6 +24,10 @@ Processors:
         ExportFormat: ""
     -
         Executable: RegRipper-ntuser.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: RegRipper-usrclass.mkape
         CommandLine: ""
         ExportFormat: ""
 

--- a/Modules/Registry/RegRipper-usrclass.mkape
+++ b/Modules/Registry/RegRipper-usrclass.mkape
@@ -1,0 +1,19 @@
+Description: 'RegRipper: parse UsrClass hives'
+Category: Registry
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 253acccb-86c0-49dd-9b6d-b9c228a49a55
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
+ExportFormat: txt
+FileMask: UsrClass.dat
+Processors:
+    -
+        Executable: regripper\rip.exe
+        CommandLine: -r %sourceFile% -f UsrClass
+        ExportFormat: txt
+        ExportFile: regripper-usrclass.txt
+
+# Documentation
+# https://github.com/keydet89/RegRipper3.0
+# Create a folder "regripper" within the "Modules\bin" KAPE folder
+# Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"


### PR DESCRIPTION
## Description

* Add module for parsing UsrClass hive
* Add module to the RegRipper-ALL compound
* Remove unneeded FileMask property in compound

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
