### PR TITLE
Added --sync Modules for RECmd and EVTXECmd, modified Compound Module, added PS 5 Sec Pause

### DIFF
--- a/Modules/EventLogs/EvtxECmd.mkape
+++ b/Modules/EventLogs/EvtxECmd.mkape
@@ -22,4 +22,3 @@ Processors:
 # https://www.youtube.com/watch?v=GhCZfCzn2l0
 # This Compound Module ensures you have the latest maps before parsing event logs
 # If you don't wnat to sync every time you parse event logs, simply run the EvtxECmd_ProcessEventLogs Module by itself
-

--- a/Modules/EventLogs/EvtxECmd.mkape
+++ b/Modules/EventLogs/EvtxECmd.mkape
@@ -1,27 +1,25 @@
-Description: 'EvtxECmd: process event log files'
+Description: 'EvtxECmd: Sync, then process event logs'
 Category: EventLogs
-Author: Eric Zimmerman
+Author: Andrew Rathbun
 Version: 1.0
-Id: 1b66f0e2-2ccf-467d-ae15-a2b3dc59df08
+Id: db70ea82-069a-42bb-9b58-68e9dae74c56
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
 ExportFormat: csv
 Processors:
     -
-        Executable: EvtxECmd\EvtxECmd.exe
-        CommandLine: -d %sourceDirectory% --csv %destinationDirectory%
-        ExportFormat: csv
+        Executable: EvtxECmd_Sync.mkape
+        CommandLine: ""
+        ExportFormat: ""
     -
-        Executable: EvtxECmd\EvtxECmd.exe
-        CommandLine: -d %sourceDirectory% --xml %destinationDirectory%
-        ExportFormat: xml
-    -
-        Executable: EvtxECmd\EvtxECmd.exe
-        CommandLine: -d %sourceDirectory% --json %destinationDirectory%
-        ExportFormat: json
+        Executable: EvtxECmd_ProcessEventLogs.mkape
+        CommandLine: ""
+        ExportFormat: ""
 
 # Documentation
 # https://github.com/EricZimmerman/evtx
 # https://binaryforay.blogspot.com/2019/04/introducing-evtxecmd.html
 # https://www.youtube.com/watch?v=YvMg3p7O6ro
 # https://www.youtube.com/watch?v=GhCZfCzn2l0
-# Be sure to run evtxecmd.exe --sync within your .\KAPE\Modules\bin\EvtxECmd directory to ensure you have the latest maps!
+# This Compound Module ensures you have the latest maps before parsing event logs
+# If you don't wnat to sync every time you parse event logs, simply run the EvtxECmd_ProcessEventLogs Module by itself
+

--- a/Modules/EventLogs/EvtxECmd_ProcessEventLogs.mkape
+++ b/Modules/EventLogs/EvtxECmd_ProcessEventLogs.mkape
@@ -1,0 +1,27 @@
+Description: 'EvtxECmd: process event log files'
+Category: EventLogs
+Author: Eric Zimmerman
+Version: 1.0
+Id: 1b66f0e2-2ccf-467d-ae15-a2b3dc59df08
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
+ExportFormat: csv
+Processors:
+    -
+        Executable: EvtxECmd\EvtxECmd.exe
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory%
+        ExportFormat: csv
+    -
+        Executable: EvtxECmd\EvtxECmd.exe
+        CommandLine: -d %sourceDirectory% --xml %destinationDirectory%
+        ExportFormat: xml
+    -
+        Executable: EvtxECmd\EvtxECmd.exe
+        CommandLine: -d %sourceDirectory% --json %destinationDirectory%
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/evtx
+# https://binaryforay.blogspot.com/2019/04/introducing-evtxecmd.html
+# https://www.youtube.com/watch?v=YvMg3p7O6ro
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Be sure to run evtxecmd.exe --sync within your .\KAPE\Modules\bin\EvtxECmd directory to ensure you have the latest maps!

--- a/Modules/EventLogs/EvtxECmd_RDP.mkape
+++ b/Modules/EventLogs/EvtxECmd_RDP.mkape
@@ -1,4 +1,4 @@
-Description: 'EvtxECmd: process event log files'
+Description: 'EvtxECmd: process RDP-related event log files'
 Category: EventLogs
 Author: Mark Hallman
 Version: 1.0

--- a/Modules/EventLogs/EvtxECmd_Sync.mkape
+++ b/Modules/EventLogs/EvtxECmd_Sync.mkape
@@ -1,0 +1,19 @@
+Description: 'EvtxECmd: Sync'
+Category: EventLogs
+Author: Andrew Rathbun
+Version: 1.0
+Id: 43ed0fa4-9d29-44a5-9cfa-3db06e5b5a46
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
+ExportFormat: ""
+Processors:
+    -
+        Executable: EvtxECmd\EvtxECmd.exe
+        CommandLine: --sync
+        ExportFormat: ""
+
+# Documentation
+# https://github.com/EricZimmerman/evtx
+# https://binaryforay.blogspot.com/2019/04/introducing-evtxecmd.html
+# https://www.youtube.com/watch?v=YvMg3p7O6ro
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# This Module ensures you have the latest Maps prior to parsing event logs with EVTXECmd

--- a/Modules/Misc/PowerShell5SecondPause.mkape
+++ b/Modules/Misc/PowerShell5SecondPause.mkape
@@ -1,0 +1,15 @@
+Description: "PowerShell: 5 Second Pause"
+Category: PowerShell
+Author: Andrew Rathbun
+Version: 1.0
+Id: 3b729407-6466-4623-869e-6c43f76c4716
+BinaryUrl: https://github.com/PowerShell/PowerShell/releases
+ExportFormat: ""
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: start-sleep 5
+        ExportFormat: ""
+
+# Documentation
+# All this Module does is give the --sync functions for RECmd, EVTXECmd, and KAPE time to execute successfully prior to performing tasks by Modules that follow

--- a/Modules/Registry/RECmd.mkape
+++ b/Modules/Registry/RECmd.mkape
@@ -7,6 +7,10 @@ BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer
 ExportFormat: csv
 Processors:
     -
+        Executable: RECmd_Sync.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
         Executable: RECmd_AllRegExecutablesFoundOrRun.mkape
         CommandLine: ""
         ExportFormat: ""

--- a/Modules/Registry/RECmd_Sync.mkape
+++ b/Modules/Registry/RECmd_Sync.mkape
@@ -1,0 +1,22 @@
+Description: 'RECmd: Sync'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: 3651465e-7165-4705-b7de-ae3006c05db0
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: ""
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: --sync
+        ExportFormat: ""
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# This Module ensures you have the latest Batch files for RECmd prior to running RECmd


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
