### PR TITLE
Add module to convert ROT13 encoded UserAssist keys

### DIFF
--- a/Modules/Registry/RECmd-Convert-Userassist.mkape
+++ b/Modules/Registry/RECmd-Convert-Userassist.mkape
@@ -1,0 +1,22 @@
+Description: Convert UserAssist keys
+Category: Registry
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 1495dc7f-e5ed-478b-a12b-0203b29aa0eb
+ExportFormat: csv
+
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: -Command "Function Rot13([string]$str, $n=13) { $value=''; For ($index= 0;$index -lt $str.length;$index++){ $ch= [byte][char]($str.substring($index,1)); if ($ch-ge 97 -and $ch -le 109){$ch=$ch+ $n} else { if ($ch-ge 110 -and $ch -le 122){$ch=$ch- $n} else { if ($ch-ge 65 -and $ch -le 77){$ch=$ch+ $n} else { if ($ch-ge 78 -and $ch -le 90){$ch=$ch -$n} } } } $value=$value+ [char]$ch } Return $value }; $files = (ls %destinationDirectory%\*_RECmd_Batch_UserActivity_Output.csv).name; write $files; foreach ($file in $files) { get-content %destinationDirectory%\$file | foreach { if ($_ -match 'UserAssist' ) { $out = $_ -match '(([^,]*,){5})([^,]*)(,.*)'; $temp = Rot13 $matches[3]; $matches[1]+$temp+$matches[4] } else { $_ } } | Out-File %destinationDirectory%\$($file)_converted.csv}"
+        ExportFormat: csv
+
+# Documentation
+# https://docs.microsoft.com/en-us/powershell/
+# UserAssist keys are Rot13 encoded. This script converts them into correct values.
+# Use the module after you run RECmd_UserActivity.mkape.
+# Output file is OriginalFilename_converted.csv.
+# The first part of the command is only for Rot13 conversion to omit the use of
+# an external PowerShell script. After $files... the search and replace is implemented.
+# All ValueName fields on UserAssist lines are then converted.
+# Rot13 function taken from https://behindthebits.blogspot.com/2014/12/rot13-in-powershell.html.


### PR DESCRIPTION
## Description

This module converts the ROT13 encoded UserAssist values found in the output of RECmd_UserActivity.mkape (*\_RECmd\_Batch\_UserActivity\_Output.csv) into correct usable values. Otherwise, the UserAssist entries are of lesser value, because in the CSV only encoded values are found.

The module can be used manually after running RECmd_UserActivity.mkape or we can add it to the RECmd compound (I would prefer that), if of value for others too, that it is automatically called after running the UserActivity command.

The output file is \<OriginalFilename\>_converted.csv but the module could also overwrite the original file, if that's better, then I will propose the needed change, of course.

The first part of the command is only the function for ROT13 conversion to omit the use of an external PowerShell script. After $files... the search and replace is implemented. All ValueName fields on UserAssist lines in the found REcmd output files are then converted. ROT13 function taken from https://behindthebits.blogspot.com/2014/12/rot13-in-powershell.html and made a one-liner.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
