### PR TITLE
Add RegRipper module to parse ntuser using provided plugin

### DIFF
--- a/Modules/Registry/RegRipper-ntuser-variable.mkape
+++ b/Modules/Registry/RegRipper-ntuser-variable.mkape
@@ -1,0 +1,21 @@
+Description: 'RegRipper: parse NTUSER hives using provided plugin name'
+Category: Registry
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: b1c7a758-664a-459d-82d5-3165772f21fc
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
+ExportFormat: txt
+FileMask: ntuser.dat
+Processors:
+    -
+        Executable: regripper\rip.exe
+        CommandLine: -r %sourceFile% -p %ntuserPlugin%
+        ExportFormat: txt
+        ExportFile: regripper-ntuser-%ntuserPlugin%.txt
+        Append: true
+
+# Documentation
+# https://github.com/keydet89/RegRipper3.0
+# Create a folder "regripper" within the "Modules\bin" KAPE folder
+# Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Provide a module variable called ntuserPlugin using --mvars


### PR DESCRIPTION
## Description

Add new RegRipper module to parse ntuser for a specific plugin. This allows using the strengh of KAPE to run one plugin against multiple hives in different locations.

See https://github.com/EricZimmerman/KapeFiles/issues/384 for a discussion about the module variable expansion in ExportFile. Currently, the output filename contains the string "%ntuserPlugin%" but with a future version this will eventually be expanded to the user supplied plugin name.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
