### PR TITLE
Adding target for Emsisoft antivirus scan logs

### DIFF
--- a/Targets/Antivirus/Emsisoft.tkape
+++ b/Targets/Antivirus/Emsisoft.tkape
@@ -10,4 +10,3 @@ Targets:
         Path: C:\ProgramData\Emsisoft\Reports\
         FileMask: scan*.txt
         Comment: "Can contain file detection and quarantine info"
-        

--- a/Targets/Antivirus/Emsisoft.tkape
+++ b/Targets/Antivirus/Emsisoft.tkape
@@ -1,0 +1,15 @@
+Description: Emsisoft Antivirus Logs
+Author: blueskycyber
+Version: 1.0
+Id: f810ea6e-eb10-4788-bff7-77bd83fe15d2
+RecreateDirectories: true
+Targets:
+    -
+        Name: Emsisoft Scan Logs
+        Category: ApplicationLogs
+        Path: C:\ProgramData\Emsisoft\Reports\
+        FileMask: scan*.txt
+        Comment: "Can contain file detection and quarantine info"
+
+# Documentation
+# N/A

--- a/Targets/Antivirus/Emsisoft.tkape
+++ b/Targets/Antivirus/Emsisoft.tkape
@@ -10,6 +10,3 @@ Targets:
         Path: C:\ProgramData\Emsisoft\Reports\
         FileMask: scan*.txt
         Comment: "Can contain file detection and quarantine info"
-
-# Documentation
-# N/A

--- a/Targets/Antivirus/Emsisoft.tkape
+++ b/Targets/Antivirus/Emsisoft.tkape
@@ -10,3 +10,6 @@ Targets:
         Path: C:\ProgramData\Emsisoft\Reports\
         FileMask: scan*.txt
         Comment: "Can contain file detection and quarantine info"
+
+# Documentation
+# N/A

--- a/Targets/Antivirus/Emsisoft.tkape
+++ b/Targets/Antivirus/Emsisoft.tkape
@@ -10,3 +10,4 @@ Targets:
         Path: C:\ProgramData\Emsisoft\Reports\
         FileMask: scan*.txt
         Comment: "Can contain file detection and quarantine info"
+        


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have generated a unique GUID for my Target(s)/Module(s)
- [X] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
