### PR TITLE
Replace variable to use the drive letter in BrowsingHistoryView module

### DIFF
--- a/Modules/BrowsingHistory/BrowsingHistoryView.mkape
+++ b/Modules/BrowsingHistory/BrowsingHistoryView.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDriveLetter%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
         ExportFormat: csv
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDriveLetter%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
         ExportFormat: html
 
 # Documentation


### PR DESCRIPTION
## Description

Currently the module assumes that only the drive letter is supplied when running kape. It uses sourceDirectory variable and adds the path to the user dir. The PR replaces the sourceDirectory to only use the drive letter so kape source paths like D:\C would also work.