### PR TITLE
Use only sourceDirectory in BrowsingHistoryView module

### DIFF
--- a/Modules/BrowsingHistory/BrowsingHistoryView.mkape
+++ b/Modules/BrowsingHistory/BrowsingHistoryView.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDriveLetter%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory% /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
         ExportFormat: csv
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDriveLetter%\C\Users\ /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory% /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
         ExportFormat: html
 
 # Documentation


### PR DESCRIPTION
Use only sourceDirectory in BrowsingHistoryView module instead of having a fix path in the module. See discussion in https://github.com/EricZimmerman/KapeFiles/pull/409/.