### PR TITLE
Add tool sync module for various EZ tools

### DIFF
--- a/Modules/!!ToolSync.mkape
+++ b/Modules/!!ToolSync.mkape
@@ -1,17 +1,18 @@
-Description: 'Sync tools and plugins'
+Description: 'Sync EZ Tools'
 Category: Misc
 Author: Andrew Rathbun, Andreas Hunkeler (@Karneades)
 Version: 1.0
 Id: 8d0a44a4-fa8e-443b-8f6e-8711ce2acd12
-BinaryUrl: See different tool modules
+BinaryUrl: See different tool Modules
 ExportFormat: ""
 Processors:
-    -
-        Executable: RECmd_Sync.mkape
-        CommandLine: ""
-        ExportFormat: ""
+
     -
         Executable: EvtxECmd_Sync.mkape
+        CommandLine: ""
+        ExportFormat: ""
+-
+        Executable: RECmd_Sync.mkape
         CommandLine: ""
         ExportFormat: ""
     -
@@ -19,8 +20,7 @@ Processors:
         CommandLine: ""
         ExportFormat: ""
 
-
 # Documentation
 # https://github.com/EricZimmerman/
-# This Module ensures you have the latest plugins, maps or reb files for various EZ tools and KAPE files.
+# This Module ensures you have the latest RECmd Batch files, EVTXECmd Maps, SQLECmd Maps, and KAPE Targets/Modules.
 # Ensure you use the tool version which provides the sync option.

--- a/Modules/!!ToolSync.mkape
+++ b/Modules/!!ToolSync.mkape
@@ -1,5 +1,5 @@
 Description: 'Sync for new Maps, Batch Files, Targets and Modules'
-Category: Misc
+Category: Sync
 Author: Andrew Rathbun, Andreas Hunkeler (@Karneades)
 Version: 1.0
 Id: 8d0a44a4-fa8e-443b-8f6e-8711ce2acd12

--- a/Modules/!!ToolSync.mkape
+++ b/Modules/!!ToolSync.mkape
@@ -1,4 +1,4 @@
-Description: 'Sync EZ Tools'
+Description: 'Sync for new Maps, Batch Files, Targets and Modules'
 Category: Misc
 Author: Andrew Rathbun, Andreas Hunkeler (@Karneades)
 Version: 1.0
@@ -8,15 +8,19 @@ ExportFormat: ""
 Processors:
 
     -
-        Executable: EvtxECmd_Sync.mkape
+        Executable: Sync_EvtxECmd.mkape
         CommandLine: ""
         ExportFormat: ""
     -
-        Executable: RECmd_Sync.mkape
+        Executable: Sync_KAPE.mkape
         CommandLine: ""
         ExportFormat: ""
     -
-        Executable: SQLECmd_Sync.mkape
+        Executable: Sync_RECmd.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Sync_SQLECmd.mkape
         CommandLine: ""
         ExportFormat: ""
 

--- a/Modules/!!ToolSync.mkape
+++ b/Modules/!!ToolSync.mkape
@@ -11,7 +11,7 @@ Processors:
         Executable: EvtxECmd_Sync.mkape
         CommandLine: ""
         ExportFormat: ""
--
+    -
         Executable: RECmd_Sync.mkape
         CommandLine: ""
         ExportFormat: ""

--- a/Modules/!!ToolSync.mkape
+++ b/Modules/!!ToolSync.mkape
@@ -1,0 +1,26 @@
+Description: 'Sync tools and plugins'
+Category: Misc
+Author: Andrew Rathbun, Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 8d0a44a4-fa8e-443b-8f6e-8711ce2acd12
+BinaryUrl: See different tool modules
+ExportFormat: ""
+Processors:
+    -
+        Executable: RECmd_Sync.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: EvtxECmd_Sync.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: SQLECmd_Sync.mkape
+        CommandLine: ""
+        ExportFormat: ""
+
+
+# Documentation
+# https://github.com/EricZimmerman/
+# This Module ensures you have the latest plugins, maps or reb files for various EZ tools and KAPE files.
+# Ensure you use the tool version which provides the sync option.


### PR DESCRIPTION
## Description

Add tool sync module for various EZ tools. See https://github.com/EricZimmerman/KapeFiles/issues/406 for discussion. Currently including the following already existing individual sync modules
* RECmd_Sync.mkape
* EvtxECmd_Sync.mkape
* SQLECmd_Sync.mkape

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
