### PR TITLE
Fix --sync calls within existing Modules

### DIFF
--- a/Modules/EventLogs/EvtxECmd.mkape
+++ b/Modules/EventLogs/EvtxECmd.mkape
@@ -7,7 +7,7 @@ BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
 ExportFormat: csv
 Processors:
     -
-        Executable: EvtxECmd_Sync.mkape
+        Executable: Sync_EvtxECmd.mkape
         CommandLine: ""
         ExportFormat: ""
     -

--- a/Modules/Registry/RECmd.mkape
+++ b/Modules/Registry/RECmd.mkape
@@ -7,7 +7,7 @@ BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer
 ExportFormat: csv
 Processors:
     -
-        Executable: RECmd_Sync.mkape
+        Executable: Sync_RECmd.mkape
         CommandLine: ""
         ExportFormat: ""
     -


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
