### PR TITLE
Remove batch sync in RECmd compound

### DIFF
--- a/Modules/Registry/RECmd.mkape
+++ b/Modules/Registry/RECmd.mkape
@@ -7,10 +7,6 @@ BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer
 ExportFormat: csv
 Processors:
     -
-        Executable: Sync_RECmd.mkape
-        CommandLine: ""
-        ExportFormat: ""
-    -
         Executable: RECmd_AllRegExecutablesFoundOrRun.mkape
         CommandLine: ""
         ExportFormat: ""


### PR DESCRIPTION
Sync is replaced by the sync module called `!!ToolSync` as discussed in https://github.com/EricZimmerman/KapeFiles/issues/406 and https://github.com/EricZimmerman/KapeFiles/pull/414.