### PR TITLE
Remove map sync in EvtxECmd

### DIFF
--- a/Modules/EventLogs/EvtxECmd.mkape
+++ b/Modules/EventLogs/EvtxECmd.mkape
@@ -7,10 +7,6 @@ BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/EvtxExplorer.zip
 ExportFormat: csv
 Processors:
     -
-        Executable: Sync_EvtxECmd.mkape
-        CommandLine: ""
-        ExportFormat: ""
-    -
         Executable: EvtxECmd_ProcessEventLogs.mkape
         CommandLine: ""
         ExportFormat: ""


### PR DESCRIPTION
Sync is replaced by !!ToolSync module

Ref #406 and #414