### PR TITLE
Add --debug to Sync Modules

### DIFF
--- a/Modules/EventLogs/Sync_EvtxECmd.mkape
+++ b/Modules/EventLogs/Sync_EvtxECmd.mkape
@@ -8,7 +8,7 @@ ExportFormat: ""
 Processors:
     -
         Executable: EvtxECmd\EvtxECmd.exe
-        CommandLine: --sync
+        CommandLine: --sync --debug
         ExportFormat: ""
 
 # Documentation

--- a/Modules/Misc/Sync_KAPE.mkape
+++ b/Modules/Misc/Sync_KAPE.mkape
@@ -8,7 +8,7 @@ ExportFormat: ""
 Processors:
     -
         Executable: kape.exe
-        CommandLine: --sync
+        CommandLine: --sync --debug
         ExportFormat: ""
 
 # Documentation

--- a/Modules/Misc/Sync_SQLECmd.mkape
+++ b/Modules/Misc/Sync_SQLECmd.mkape
@@ -8,7 +8,7 @@ ExportFormat: ""
 Processors:
     -
         Executable: SQLECmd\SQLECmd.exe
-        CommandLine: --sync
+        CommandLine: --sync --debug
         ExportFormat: ""
 
 # Documentation

--- a/Modules/Registry/Sync_RECmd.mkape
+++ b/Modules/Registry/Sync_RECmd.mkape
@@ -8,7 +8,7 @@ ExportFormat: ""
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: --sync
+        CommandLine: --sync --debug
         ExportFormat: ""
 
 # Documentation


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
