### PR TITLE
Create SumatraPDF.tkape

### DIFF
--- a/Targets/Apps/SumatraPDF.tkape
+++ b/Targets/Apps/SumatraPDF.tkape
@@ -1,0 +1,19 @@
+Description: SumatraPDF
+Author: Andrew Rathbun
+Version: 1.0
+Id: c3a2d097-bca5-4ebe-83b2-db509c86883f
+RecreateDirectories: true
+Targets:
+    -
+        Name: SumatraPDF Settings - SessionData
+        Category: FileKnowledge
+        Path: C:\Users\%user%\AppData\Local\SumatraPDF
+        FileMask: SumatraPDF-settings.txt
+        Recursive: false
+        Comment: Settings file which contains information about previous user session
+
+
+# Documentation
+# https://www.sumatrapdfreader.org/settings/settings.html
+# In the above link, search for SessionData to warp to the applicable information you can find for what documents the user had opened within SumatraPDF at the last time of program exit
+# I've had 170+ PDFs opened at once with SumatraPDF and each of their full file paths were recorded within this file. Very useful!


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
