### PR TITLE
Create WindowsOSUpgradeArtifacts.tkape

### DIFF
--- a/Targets/Windows/WindowsOSUpgradeArtifacts.tkape
+++ b/Targets/Windows/WindowsOSUpgradeArtifacts.tkape
@@ -1,0 +1,25 @@
+Description: Windows OS Upgrade Artifacts
+Author: Andrew Rathbun
+Version: 1.0
+Id: e223d74f-7f36-46e8-b4ec-6d46f695a717
+RecreateDirectories: true
+Targets:
+    -
+        Name: MigLog.xml
+        Category: OS Upgrade
+        Path: C:\Windows\Panther
+        FileMask: MigLog.xml
+    -
+        Name: Setupact.log
+        Category: OS Upgrade
+        Path: C:\Windows\Panther
+        FileMask: Setupact.log
+
+# Documentation
+# https://cyberarms.wordpress.com/2012/08/30/windows-8-forensics-reset-and-refresh-artifacts/
+# #MigLog.xml appears to provide a large list of settings, users, and other configuration settings that have been migrated from one OS version to another
+# There appears to be a lot of registry entries that are enumerated within this log, so this can serve as a potentially good snapshot in time of a user's system registry
+# Setupact.log has some good information about the hardware configuration of the system, current antivirus, and what appears to be an enumeration of the registry keys/subkeys
+# Setupact.log appears to provide good historical information about a system at the time of OS Upgrade (i.e. W10 2004 upgrading to W10 20H2)
+# https://en.wikipedia.org/wiki/Windows_10_version_history will provide a history of when W10 updates have released. Assuming the target system had a user that was timely with their OS updates, one could plan on artifacts to reflect around the dates of OS update release dates
+# On my personal system, MigLog.xml was 245mb and setupact.log was 151mb, so be cognizant of the potentially large file size of these artifacts compared to other artifacts that store this same information


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
