### PR TITLE
Create MediaMonkey and TreeSize Targets, create MFTECmd_$MFT_FileListing Module, and update WindowsYourPhone Target

### DIFF
--- a/Modules/FileSystem/MFTECmd_$MFT_FileLIsting.mkape
+++ b/Modules/FileSystem/MFTECmd_$MFT_FileLIsting.mkape
@@ -1,0 +1,30 @@
+Description: 'MFTECmd: process $MFT files, then output file listing'
+Category: FileSystem
+Author: Andrew Rathbun
+Version: 1.0
+Id: 8bcb68fa-b62a-4347-b3cb-b00d72b2752d
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
+ExportFormat: csv
+FileMask: $MFT
+Processors:
+    -
+        Executable: MFTECmd.exe
+        CommandLine: -f %sourceFile% --csv %destinationDirectory% --fl
+        ExportFormat: csv
+    -
+        Executable: MFTECmd.exe
+        CommandLine: -f %sourceFile% --json %destinationDirectory% --fl
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/MFTECmd
+# https://binaryforay.blogspot.com/2018/06/introducing-mftecmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/mft-explorer-mftecmd/
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# This is the same as MFTECmd_$MFT.mkape, but it'll output a file listing that comprises of only the following columns:
+# Full Path (aka Parent Path and File Name combined from MFTECmd CSV Output)
+# Extension
+# Is Directory
+# File Size
+# Created0x10
+# Last Modified0x10

--- a/Targets/Apps/MediaMonkey.tkape
+++ b/Targets/Apps/MediaMonkey.tkape
@@ -1,0 +1,24 @@
+Description: MediaMonkey
+Author: Andrew Rathbun
+Version: 1.0
+Id: d37bb0d2-6870-4159-8823-e0943fc42ae2
+RecreateDirectories: true
+Targets:
+    -
+        Name: MediaMonkey - Media SQLite Database
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\MediaMonkey
+        FileMask: 'MM.DB'
+        Comment: "Locates SQLite DB that contains a complete enumeration of the user's media collection within MediaMonkey"
+    -
+        Name: MediaMonkey - MediaMonkey.ini
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\MediaMonkey
+        FileMask: 'MediaMonkey.ini'
+        Comment: "Locates .ini file which contains information about the user's MediaMonkey application instance"
+
+# Documentation
+# https://www.mediamonkey.com/support/knowledge-base/mediamonkey-install-config/modifying-the-mediamonkey-db-and-ini-files/
+# MediaMonkey is a popular media organizing, tagging, and playing application for Windows
+# MM.DB contains information about any files added to a user's MediaMonkey library, including music and video files
+# MediaMonkey.ini will contain file paths pointing to where a user stores media that's being viewed within MediaMonkey

--- a/Targets/Apps/TreeSize.tkape
+++ b/Targets/Apps/TreeSize.tkape
@@ -1,0 +1,26 @@
+Description: TreeSize - Scan History
+Author: Andrew Rathbun
+Version: 1.0
+Id: b7e88f6b-3474-46b1-9c0b-1eed65dfc379
+RecreateDirectories: true
+Targets:
+    -
+        Name: TreeSize - ScanHistory.XML
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\JAM Software\TreeSize
+        FileMask: 'scanhistory.xml'
+        Comment: "Locates XML file that provides a list of previously scanned directories by the user."
+
+# Documentation
+# https://www.jam-software.com/treesize_free
+# TreeSize is a program similar to WinDirStat which allows the user to enumerate their computer's file system in a variety of ways
+# ScanHistory.XML will provide listings that look similar to this
+# <SCANS>
+# 	<Root path="\\HOSTNAME\C$\">
+# 		<Path>\\HOSTNAME\C$\</Path>
+# 		<Date>44148.3234845949</Date>
+# 		<Version>8.0.2.1505</Version>
+# 		<SizeData Size="210610089818" Allocated="187592699904" Files="678331"/>
+# 		<Freespace>814266826752</Freespace>
+# 	</Root>
+# For each scan ran, there will be an entry in this file

--- a/Targets/Windows/WindowsYourPhone.tkape
+++ b/Targets/Windows/WindowsYourPhone.tkape
@@ -16,26 +16,26 @@ Targets:
 # This has only been tested with Android at this time. I don't own an Apple device but if someone else does, feel free to edit this target file with iOS related information.
 # This target will recursively grab folders with a complete file path similar to this one: .\AppData\Local\Packages\Microsoft.YourPhone_8wekyb3d8bbwe\LocalCache\Indexed\GUID\System\Database\.
 # Inside this directory on my system were the following files
-#    photos.db
-#    phone.db
-#    photos.db-wal
-#    phone.db-wal
-#    settings.db-wal
-#    settings.db
-#    contacts.db-wal
-#    contacts.db
-#    deviceData.db-wal
-#    calling.db-shm
-#    contacts.db-shm
-#    deviceData.db-shm
-#    notifications.db-shm
-#    phone.db-shm
-#    photos.db-shm
-#    settings.db-shm
-#    calling.db-wal
-#    notifications.db-wal
 #    calling.db
-# Throw any of these files into a SQLite viewer such as SQLite Expert Pro to view the contents.
+#    calling.db-shm
+#    calling.db-wal
+#    contacts.db
+#    contacts.db-shm
+#    contacts.db-wal
+#    deviceData.db-shm
+#    deviceData.db-wal
+#    notifications.db-shm
+#    notifications.db-wal
+#    phone.db
+#    phone.db-shm
+#    phone.db-wal
+#    photos.db
+#    photos.db-shm
+#    photos.db-wal
+#    settings.db
+#    settings.db-shm
+#    settings.db-wal
+# Throw any of these files into a SQLite viewer such as SQLite Expert Pro or DB Browser for SQLite to view the contents.
 # A quick rundown:
 #    Photos.db will have filenames and blob files.
 #    Phone.db will contain all text messages on the device, including RCS chats, conversations, and file transfers, MMS messages, etc.


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
