### PR TITLE
Update Dropbox Target, added Documentation within various Targets

### DIFF
--- a/Targets/Apps/Dropbox.tkape
+++ b/Targets/Apps/Dropbox.tkape
@@ -1,6 +1,6 @@
 Description: Dropbox Cloud Storage Files and Metadata
-Author: Chad Tilbury
-Version: 1.0
+Author: Chad Tilbury and Andrew Rathbun
+Version: 1.1
 Id: e8501b5d-2cfc-4693-923d-52edd2ddf3bc
 RecreateDirectories: true
 Targets:
@@ -33,6 +33,24 @@ Targets:
         Path: C:\Users\%user%\AppData\Roaming\Microsoft\Protect\*\
         Recursive: true
         Comment: "Required for offline decryption of Dropbox databases"
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\*\
+        FileMask: home.db
+        Comment: "SQlite database which appears to keep track of the user's recent Dropbox activity"
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\*\
+        FileMask: sync_history.db
+        Comment: "SQLite database which appears to keep track of the user's Drobox sync history"
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\*\sync\
+        FileMask: nucleus.sqlite3*
+        Comment: "SQLite database which appears to contain a table for deleted files"
 
 # Documentation
 # https://www.marshall.edu/forensics/files/Treleven-Dropbox-Paper-FINAL.pdf
@@ -42,3 +60,4 @@ Targets:
 # https://www.researchgate.net/publication/342991973_Forensic_Analysis_of_Dropbox_Data_Remnants_on_Windows_10
 # https://www.atropos4n6.com/cloud-forensics/windows-10-artifacts-of-dropboxs-native-app-usage/
 # https://www.atropos4n6.com/cloud-forensics/artifacts-of-dropbox-usage-on-windows-10-part-2/
+# home.db, sync_history.db, and nucleus.sqlite* are SQLite databases. SQLECmd maps will be forthcoming! In the meantime, examine in DB Browser for SQLite

--- a/Targets/Apps/TeamViewerLogs.tkape
+++ b/Targets/Apps/TeamViewerLogs.tkape
@@ -28,3 +28,4 @@ Targets:
 # https://svch0st.medium.com/writeup-magnet-user-summit-dfir-ctf-2019-activity-79cf149c04d7
 # https://www.systoolsgroup.com/forensics/teamviewer/
 # https://athenaforensics.co.uk/teamviewer-forensics/
+# https://medium.com/mii-cybersec/digital-forensic-artifact-of-teamviewer-application-cfd6290dc0a7

--- a/Targets/Windows/WindowsYourPhone.tkape
+++ b/Targets/Windows/WindowsYourPhone.tkape
@@ -15,7 +15,7 @@ Targets:
 # https://iconline.ipleiria.pt/bitstream/10400.8/4179/1/Digital_forensic_artifacts_YourPhone_W10.pdf
 # This has only been tested with Android at this time. I don't own an Apple device but if someone else does, feel free to edit this target file with iOS related information.
 # This target will recursively grab folders with a complete file path similar to this one: .\AppData\Local\Packages\Microsoft.YourPhone_8wekyb3d8bbwe\LocalCache\Indexed\GUID\System\Database\.
-# Inside this directory on my system were the following files
+# Inside this directory on my system were the following files:
 #    calling.db
 #    calling.db-shm
 #    calling.db-wal
@@ -42,3 +42,5 @@ Targets:
 #    Contacts.db will contact all contact names, numbers, addresses, email addresses, etc.
 #    Settings.db will contain an enumerated list of installed apps on the device.
 #    Calling.db will contain call history.
+#    Notifications.db will show the active notifications from the device.
+#    DeviceData.db will have the current wallpaper that's displayed on the device.


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
