### PR TITLE
Add WindowsIndexSearch parsing using ESEDatabaseView

### DIFF
--- a/Modules/FileSystem/WindowsIndexSearch.mkape
+++ b/Modules/FileSystem/WindowsIndexSearch.mkape
@@ -1,0 +1,18 @@
+Description: 'Windows Index Search - Nirsoft'
+Category: FileSystem
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 701cb5fe-f241-4806-9339-33d7ed030b92
+BinaryUrl: https://www.nirsoft.net/utils/esedatabaseview.zip
+ExportFormat: csv
+FileMask: Windows.edb
+Processors:
+    -
+        Executable: ESEDatabaseView.exe
+        CommandLine: /table %sourceFile% * /scomma "%destinationDirectory%\WindowsIndexSearch_*.csv"
+        ExportFormat: csv
+
+# Documentation
+# Uses Nirsoft's ESEDatabaseView to export Windows index search tables to CSV
+# https://www.nirsoft.net/utils/ese_database_view.html
+# Other tool to parse and analyze Windows.edb files: https://github.com/moaistory/WinSearchDBAnalyzer


### PR DESCRIPTION
## Description

Add WindowsIndexSearch parsing using ESEDatabaseView. Currently, we collect the Windows Index Search DB through !BasicCollection but lack a module to parse it. One way is to use the ESEDatabaseView which extracts some basic infos from the DB.

I put it into the FS folder because it gives file and folder information.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
