### PR TITLE
Fix path issue by using quotes around PS script paths

### DIFF
--- a/Modules/LiveResponse/Get-InjectedThread.mkape
+++ b/Modules/LiveResponse/Get-InjectedThread.mkape
@@ -8,7 +8,7 @@ ExportFormat: json
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "Import-Module %kapedirectory%\Modules\bin\Get-InjectedThread.ps1 -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\Get-InjectedThread.json"
+        CommandLine: -Command "Import-Module '%kapedirectory%\Modules\bin\Get-InjectedThread.ps1' -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-InjectedThread.json'"
         ExportFormat: json
 
 # Documentation

--- a/Modules/LiveResponse/Get-InjectedThread.mkape
+++ b/Modules/LiveResponse/Get-InjectedThread.mkape
@@ -8,7 +8,7 @@ ExportFormat: json
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "Import-Module '%kapedirectory%\Modules\bin\Get-InjectedThread.ps1' -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-InjectedThread.json'"
+        CommandLine: -ep bypass -Command "Import-Module '%kapedirectory%\Modules\bin\Get-InjectedThread.ps1' -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-InjectedThread.json'"
         ExportFormat: json
 
 # Documentation

--- a/Modules/LiveResponse/Get-NetworkConnection.mkape
+++ b/Modules/LiveResponse/Get-NetworkConnection.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.csv"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.csv'"
         ExportFormat: csv
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.json"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.json'"
         ExportFormat: json
 
 # Documentation

--- a/Modules/LiveResponse/Get-NetworkConnection.mkape
+++ b/Modules/LiveResponse/Get-NetworkConnection.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.csv'"
+        CommandLine: -ep bypass -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.csv'"
         ExportFormat: csv
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.json'"
+        CommandLine: -ep bypass -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.json'"
         ExportFormat: json
 
 # Documentation


### PR DESCRIPTION
Make running kape more robust by allowing to have spaces in folder names in PS modules and when the script policy limits the execution of the ps scripts.