### PR TITLE
Updated LevelDB Dumper module to use new arguments and formats

### DIFF
--- a/Modules/Misc/LevelDBDumper.mkape
+++ b/Modules/Misc/LevelDBDumper.mkape
@@ -1,15 +1,20 @@
 Description: Dumps LevelDB Key/Value databases
 Category: Databases
 Author: Matt Dawson
-Version: 1.0
+Version: 1.1
 Id: 3a88b531-705b-487d-933c-75ce0921a656
 BinaryUrl: https://github.com/mdawsonuk/LevelDBDumper/releases
 ExportFormat: csv
 Processors:
     -
         Executable: LevelDBDumper.exe
-        CommandLine: "-d %sourceDirectory% --csv %destinationDirectory% -q"
+        CommandLine: "-d %sourceDirectory% -o %destinationDirectory% -t csv -q --no-header --no-colour"
         ExportFormat: csv
+        ExportFile: "LevelDBDumperOutput.log"
+    -
+        Executable: LevelDBDumper.exe
+        CommandLine: "-d %sourceDirectory% -o %destinationDirectory% -t json -q --no-header --no-colour"
+        ExportFormat: json
         ExportFile: "LevelDBDumperOutput.log"
 
 # Documentation


### PR DESCRIPTION
## Description

Updated LevelDB Dumper module to use the new command line arguments and added support for JSON output format

## Checklist:

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format