### PR TITLE
Update SumECmd CommandLine path

### DIFF
--- a/Modules/Misc/SumECmd.mkape
+++ b/Modules/Misc/SumECmd.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: SumECmd.exe
-        CommandLine: -d %sourceDirectory% --csv %destinationDirectory%
+        CommandLine: -d %sourceDirectory%\Users\Windows\System32\LogFiles\SUM --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation
@@ -16,3 +16,6 @@ Processors:
 # https://twitter.com/EricRZimmerman/status/1363878700123643904?s=20
 # https://svch0st.medium.com/windows-user-access-logs-ual-9580f1100635
 # .\KAPE\Targets\Windows\LogFiles.tkape will capture the SUM Database which is located at C:\Windows\System32\LogFiles\SUM
+# This Module is meant to work in conjunction with the LogFiles.tkape acquiring the necessary files for SumECmd to parse in one fell swoop. 
+# When running this Module by itself, make sure your Module Source is pointed to the root of a drive or a folder path with structure similar to what is listed within the CommandLine above, if possible. 
+# If that's not the case, then run the SumECmd tool by itself against your directory with a similar command as stated above or modify the path within the CommandLine of your local copy of this Module to make it fit your circumstances.

--- a/Modules/Misc/SumECmd.mkape
+++ b/Modules/Misc/SumECmd.mkape
@@ -16,6 +16,6 @@ Processors:
 # https://twitter.com/EricRZimmerman/status/1363878700123643904?s=20
 # https://svch0st.medium.com/windows-user-access-logs-ual-9580f1100635
 # .\KAPE\Targets\Windows\LogFiles.tkape will capture the SUM Database which is located at C:\Windows\System32\LogFiles\SUM
-# This Module is meant to work in conjunction with the LogFiles.tkape acquiring the necessary files for SumECmd to parse in one fell swoop. 
-# When running this Module by itself, make sure your Module Source is pointed to the root of a drive or a folder path with structure similar to what is listed within the CommandLine above, if possible. 
+# This Module is meant to work in conjunction with the LogFiles.tkape acquiring the necessary files for SumECmd to parse in one fell swoop.
+# When running this Module by itself, make sure your Module Source is pointed to the root of a drive or a folder path with structure similar to what is listed within the CommandLine above, if possible.
 # If that's not the case, then run the SumECmd tool by itself against your directory with a similar command as stated above or modify the path within the CommandLine of your local copy of this Module to make it fit your circumstances.


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
