### PR TITLE
Add required folder to BrowsingHistoryView command

### DIFF
--- a/Modules/BrowsingHistory/BrowsingHistoryView.mkape
+++ b/Modules/BrowsingHistory/BrowsingHistoryView.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory% /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory%\Users /VisitTimeFilterType 1 /ShowTimeInGMT 1 /scomma %destinationDirectory%\BrowsingHistory.csv
         ExportFormat: csv
     -
         Executable: browsinghistoryview.exe
-        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory% /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
+        CommandLine: /HistorySource 3 /HistorySourceFolder %sourceDirectory%\Users /VisitTimeFilterType 1 /ShowTimeInGMT 1 /sverhtml  %destinationDirectory%\BrowsingHistory.html
         ExportFormat: html
 
 # Documentation


### PR DESCRIPTION
We use `sourceDirectory` to be flexible if source drive is C or whatever, but I would add now the required part "users" to the path again, so it works directly when invoking e.g. `kape.exe -msource D:\C` or `kape.exe -msource D:\E` or whatever. This is now a combination from the previous too static `%sourceDirectory%\C\Users\` and the last one using only `%sourceDirectory%` which needed always a `...\Users` explicitly in the -msource.

I missed that in the past PR and it didn't came up in the discussions in #409. Hope now it covers everything (flexible in regards to drive letter but still directly usable due to the addition of the required users in the path).