### PR TITLE
Add missing SQLECmd maps to targets

### DIFF
--- a/Targets/Apps/MicrosoftStickyNotes.tkape
+++ b/Targets/Apps/MicrosoftStickyNotes.tkape
@@ -20,4 +20,4 @@ Targets:
 # Microsoft Sticky Notes is a useful feature in Windows operating systems versions 7+. However, the notes are stored differently depending on the version of Windows.
 # I have not yet tested the Stickynotes.snt for earlier versions of Windows. When I do, I will update this target with my results.
 # For Windows 10 version 1607 and later, use your favorite SQL tool to view the .sqlite, .sqlite-wal and .sqlite-shm files. You will notice notes will be stored in the Note database.
-# There is now a SQLECmd Map for the plum.sqlite database: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Apps/MicrosoftStickyNotes.tkape
+# There is now a SQLECmd Map for the plum.sqlite database: https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/Windows_MicrosoftStickyNotes_NotesDB.smap

--- a/Targets/Apps/WindowsYourPhone.tkape
+++ b/Targets/Apps/WindowsYourPhone.tkape
@@ -39,9 +39,13 @@ Targets:
 # A quick rundown:
 #    Photos.db will have filenames and blob files.
 #    Phone.db will contain all text messages on the device, including RCS chats, conversations, and file transfers, MMS messages, etc.
-#    Contacts.db will contact all contact names, numbers, addresses, email addresses, etc.
+#    Contacts.db will contain all contact names, numbers, addresses, email addresses, etc.
 #    Settings.db will contain an enumerated list of installed apps on the device.
 #    Calling.db will contain call history.
 #    Notifications.db will show the active notifications from the device.
 #    DeviceData.db will have the current wallpaper that's displayed on the device.
-# There is now a SQLECmd Map for this database: https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Apps/WindowsYourPhone.tkape
+# There are now SQLECmd maps for this databases:
+#    https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/Windows_YourPhone_NotificationsDB.smap
+#    https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/Windows_YourPhone_PhoneDB-SMSMessages.smap
+#    https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/Windows_YourPhone_PhotosDB.smap
+#    https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/Windows_YourPhone_SettingsDB.smap

--- a/Targets/Windows/WindowsTimeline.tkape
+++ b/Targets/Windows/WindowsTimeline.tkape
@@ -18,3 +18,4 @@ Targets:
 # https://www.andreafortuna.org/2019/10/03/some-forensic-thoughts-about-windows-10-timeline/
 # https://salt4n6.com/2018/05/03/windows-10-timeline-forensic-artefacts/
 # https://cyberforensicator.com/2018/05/08/wxtcmd-windows-10-timeline-parser/
+# There is a SQLECmd map for the ActivitiesCache.db database: https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/Windows_ActivitiesCache.smap


### PR DESCRIPTION
Add missing links for SQLECmd maps in WindowsYourPhone, WindowsTimeline and MicrosoftStickyNotes.

@rathbuna Besides that, in the file listing in [WindowsYourPhone.tkape](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Apps/WindowsYourPhone.tkape) a `Notifications.db` is missing but in the [map](https://github.com/EricZimmerman/SQLECmd/blob/master/SQLMap/Maps/Windows_YourPhone_NotificationsDB.smap) the filename required is `Notifications.db`.