### PR TITLE
Add RegRipper modules to parse different hives using specific plugin 

### DIFF
--- a/Modules/Registry/RegRipper-security-variable.mkape
+++ b/Modules/Registry/RegRipper-security-variable.mkape
@@ -1,0 +1,21 @@
+Description: 'RegRipper: parse SECURITY hive using provided plugin name'
+Category: Registry
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 8743b688-bebf-4ae5-8700-aed6681fc4eb
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
+ExportFormat: txt
+FileMask: SECURITY
+Processors:
+    -
+        Executable: regripper\rip.exe
+        CommandLine: -r %sourceFile% -p %securityPlugin%
+        ExportFormat: txt
+        ExportFile: regripper-security-%securityPlugin%.txt
+        Append: true
+
+# Documentation
+# https://github.com/keydet89/RegRipper3.0
+# Create a folder "regripper" within the "Modules\bin" KAPE folder
+# Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Provide a module variable called using --mvars securityPlugin:pluginname

--- a/Modules/Registry/RegRipper-software-variable.mkape
+++ b/Modules/Registry/RegRipper-software-variable.mkape
@@ -1,0 +1,21 @@
+Description: 'RegRipper: parse SOFTWARE hive using provided plugin name'
+Category: Registry
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: c2e63e6f-4207-4bf4-b6af-d4a465009418
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
+ExportFormat: txt
+FileMask: SOFTWARE
+Processors:
+    -
+        Executable: regripper\rip.exe
+        CommandLine: -r %sourceFile% -p %softwarePlugin%
+        ExportFormat: txt
+        ExportFile: regripper-software-%softwarePlugin%.txt
+        Append: true
+
+# Documentation
+# https://github.com/keydet89/RegRipper3.0
+# Create a folder "regripper" within the "Modules\bin" KAPE folder
+# Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Provide a module variable using --mvars softwarePlugin:pluginname

--- a/Modules/Registry/RegRipper-system-variable.mkape
+++ b/Modules/Registry/RegRipper-system-variable.mkape
@@ -1,0 +1,21 @@
+Description: 'RegRipper: parse SYSTEM hive using provided plugin name'
+Category: Registry
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 2eda739f-6af9-4b53-8d63-2c1154701a7c
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
+ExportFormat: txt
+FileMask: SYSTEM
+Processors:
+    -
+        Executable: regripper\rip.exe
+        CommandLine: -r %sourceFile% -p %systemPlugin%
+        ExportFormat: txt
+        ExportFile: regripper-system-%systemPlugin%.txt
+        Append: true
+
+# Documentation
+# https://github.com/keydet89/RegRipper3.0
+# Create a folder "regripper" within the "Modules\bin" KAPE folder
+# Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Provide a module variable using --mvars systemPlugin:pluginname

--- a/Modules/Registry/RegRipper-usrclass-variable.mkape
+++ b/Modules/Registry/RegRipper-usrclass-variable.mkape
@@ -1,0 +1,21 @@
+Description: 'RegRipper: parse UsrClass hives using provided plugin name'
+Category: Registry
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: 26a1534a-c11d-4434-96c5-864699513aee
+BinaryUrl: https://github.com/keydet89/RegRipper3.0/archive/master.zip
+ExportFormat: txt
+FileMask: UsrClass.dat
+Processors:
+    -
+        Executable: regripper\rip.exe
+        CommandLine: -r %sourceFile% -p %usrclassPlugin%
+        ExportFormat: txt
+        ExportFile: regripper-usrclass-%usrclassPlugin%.txt
+        Append: true
+
+# Documentation
+# https://github.com/keydet89/RegRipper3.0
+# Create a folder "regripper" within the "Modules\bin" KAPE folder
+# Place "rip.exe", "p2x5124.dll" and the "plugins" folder into "Modules\bin\regripper"
+# Provide a module variable using --mvars usrclassPlugin:pluginname


### PR DESCRIPTION
## Description

Add new RegRipper modules to parse more hives for a specific plugin. This allows using the strength of KAPE to run one plugin against multiple hives in different locations without the need for search for them (e.g. usrclass in different profiles, ...).

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
