### PR TITLE
Update Chrome and Dropbox

### DIFF
--- a/Targets/Apps/Dropbox.tkape
+++ b/Targets/Apps/Dropbox.tkape
@@ -1,6 +1,6 @@
 Description: Dropbox Cloud Storage Files and Metadata
 Author: Chad Tilbury and Andrew Rathbun
-Version: 1.1
+Version: 1.3
 Id: e8501b5d-2cfc-4693-923d-52edd2ddf3bc
 RecreateDirectories: true
 Targets:
@@ -19,7 +19,7 @@ Targets:
         Name: Dropbox Metadata
         Category: Apps
         Path: C:\Users\%user%\AppData\Local\Dropbox\*\
-        FileMask: filecache.dbx
+        FileMask: filecache.db*
         Comment: "Getting individual files because folder may contain very large extraneous files"
     -
         Name: Dropbox Metadata
@@ -43,6 +43,12 @@ Targets:
         Name: Dropbox Metadata
         Category: Apps
         Path: C:\Users\%user%\AppData\Local\Dropbox\*\
+        FileMask: icon.db
+        Comment: "SQLite database which appears to keep track of icons in the user's Drobox sync history which can give an indication as to which files and folders are present"
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\*\
         FileMask: sync_history.db
         Comment: "SQLite database which appears to keep track of the user's Drobox sync history"
     -
@@ -51,6 +57,30 @@ Targets:
         Path: C:\Users\%user%\AppData\Local\Dropbox\*\sync\
         FileMask: nucleus.sqlite3*
         Comment: "SQLite database which appears to contain a table for deleted files"
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\
+        FileMask: host.db
+        Comment: "SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\
+        FileMask: host.dbx
+        Comment: "SQLite database which contains the local path of the user's Dropbox folder encoded in BASE64. Decode each line separately, not together."
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\*\sync\
+        FileMask: aggregation.dbx
+        Comment: "SQLite database which appears to contain snapshot table of the user's Dropbox contents in JSON with timestamps in UNIX Epoch"
+    -
+        Name: Dropbox Metadata
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Dropbox\*\
+        FileMask: avatarcache.db
+        Comment: "SQLite database which appears to contain the ID's of account(s) on the user's system where Dropbox is installed"
 
 # Documentation
 # https://www.marshall.edu/forensics/files/Treleven-Dropbox-Paper-FINAL.pdf

--- a/Targets/Browsers/Chrome.tkape
+++ b/Targets/Browsers/Chrome.tkape
@@ -95,6 +95,11 @@ Targets:
         Path: C:\Users\%user%\AppData\Local\Google\Chrome\User Data\*\
         FileMask: Current Tabs
     -
+        Name: Chrome Download Metadata
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Local\Google\Chrome\User Data\*\
+        FileMask: Download Metadata
+    -
         Name: Chrome Extension Cookies
         Category: Communications
         Path: C:\Users\%user%\AppData\Local\Google\Chrome\User Data\*\
@@ -153,7 +158,7 @@ Targets:
         Name: Chrome Quota Manager
         Category: Communications
         Path: C:\Users\%user%\AppData\Local\Google\Chrome\User Data\*\
-        FileMask: Quota Manager
+        FileMask: QuotaManager
     -
         Name: Chrome Reporting and NEL
         Category: Communications


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
