### PR TITLE
Microsoft Exchange CVE-2021-26855 *.compiled hunter.

### DIFF
--- a/Targets/Apps/ExchangeCompiled.tkape
+++ b/Targets/Apps/ExchangeCompiled.tkape
@@ -11,7 +11,6 @@ Targets:
         Recursive: true
         FileMask: '*.\b[a-zA-Z0-9]{8}\b.compiled'
         Comment: "Highly dependent on Exchange configuration"
-   
 
 # Documentation
 # Microsoft Exchange CVE-2021-26855 - the *.compound files are modified XML files that point to the#

--- a/Targets/Apps/ExchangeCompiled.tkape
+++ b/Targets/Apps/ExchangeCompiled.tkape
@@ -1,0 +1,20 @@
+Description: Exchange Server Vulnerability Malicious *.Compiled Files
+Author: Dennis Reneau
+Version: 1.0
+Id: e7dc72be-942c-4fef-aa45-252bf2364b1e
+RecreateDirectories: true
+Targets:
+    -
+        Name: Exchange Server Modified Compiled Files
+        Category: Apps
+        Path: \*\Windows\Microsoft.NET\Framework*\v*\Temporary ASP.NET Files\
+        Recursive: true
+        FileMask: '*.\b[a-zA-Z0-9]{8}\b.compiled'
+        Comment: "Highly dependent on Exchange configuration"
+   
+
+# Documentation
+# Microsoft Exchange CVE-2021-26855 - the *.compound files are modified XML files that point to the#
+# associated dll's and can be used to identify the filedep name. The *.compound files located to date have #
+# taken the name of the *.aspx file they are associated with, ex. Sample.aspx - - > Sample.aspx.########.compiled.#
+# N/A

--- a/Targets/Apps/ExchangeCompiled.tkape
+++ b/Targets/Apps/ExchangeCompiled.tkape
@@ -13,7 +13,7 @@ Targets:
         Comment: "Highly dependent on Exchange configuration"
 
 # Documentation
-# Microsoft Exchange CVE-2021-26855 - the *.compound files are modified XML files that point to the#
-# associated dll's and can be used to identify the filedep name. The *.compound files located to date have #
-# taken the name of the *.aspx file they are associated with, ex. Sample.aspx - - > Sample.aspx.########.compiled.#
+# Microsoft Exchange CVE-2021-26855
+# *.compound files are modified XML files associated with malicious dll's through their internal coding.
+# The *.compound files can be used to identify the filedep (the *.aspx file they are associated with, ex. Sample.aspx - - > Sample.aspx.########.compiled).
 # N/A

--- a/Targets/Apps/ExchangeCompiled.tkape
+++ b/Targets/Apps/ExchangeCompiled.tkape
@@ -15,5 +15,6 @@ Targets:
 # Documentation
 # Microsoft Exchange CVE-2021-26855
 # *.compound files are modified XML files associated with malicious dll's through their internal coding.
-# The *.compound files can be used to identify the filedep (the *.aspx file they are associated with, ex. Sample.aspx - - > Sample.aspx.########.compiled).
+# The *.compound files can be used to identify the filedep (the *.aspx file they are associated with, ex. 
+#Sample.aspx - - > Sample.aspx.########.compiled).
 # N/A


### PR DESCRIPTION
Microsoft Exchange CVE-2021-26855 *.compiled threat hunter.

## Description
KAPE Target used to locate *.compound files associated with CVE-2021-26855. These files are modified XML files that point to the malicious dll's and can be used to identify the filedep name. The *.compound files located to date have taken the name of the *.aspx file they are associated with, ex. Sample.aspx - - > Sample.aspx.########.compiled.#

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ X] I have generated a unique GUID for my Target(s)/Module(s)
- [ X] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ X] I have set or updated the version of my Target(s)/Module(s)
- [X ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [X] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
