### PR TITLE
Create Q-Dir, update FileExplorerReplacements

### DIFF
--- a/Targets/Apps/Q-Dir.tkape
+++ b/Targets/Apps/Q-Dir.tkape
@@ -1,0 +1,24 @@
+Description: Q-Dir
+Author: Andrew Rathbun
+Version: 1.0
+Id: 1233adac-a6ec-4bba-abe6-c827ba5e27ea
+RecreateDirectories: true
+Targets:
+    -
+        Name: Q-Dir - .ini File
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Q-Dir\
+        FileMask: 'Q-Dir.ini'
+        Comment: "Locates .ini file associated with Q-Dir which stores useful user activity information."
+    -
+        Name: Q-Dir - .qdr file
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Q-Dir\
+        FileMask: 'start.qdr'
+        Comment: "Locates .qdr file associated with Q-Dir which stores useful user activity information, including the last 4 folders opened (encoded, unfortunately)."
+
+# Documentation
+# Q-Dir is a freeware Windows File Explorer replacement similar to Total Commander and other orthodox file managers.
+# Q-Dir has limited FTP functionality as of April 2021.
+# The .ini is not the most helpful. It appears everything is stored in a currently unknown encoding format.
+# Same story for start.qdr. However, this is where all the info the program stores at this time resides.

--- a/Targets/Compound/FileExplorerReplacements.tkape
+++ b/Targets/Compound/FileExplorerReplacements.tkape
@@ -1,6 +1,6 @@
 Description: File Explorer Replacements
 Author: Andrew Rathbun
-Version: 1.1
+Version: 1.2
 Id: 8e1cb436-dada-413f-845d-f2ed0823cb3a
 RecreateDirectories: true
 Targets:
@@ -21,6 +21,10 @@ Targets:
         Category: Apps
         Path: MultiCommander.tkape
     -
+        Name: Q-Dir
+        Category: Apps
+        Path: Q-Dir.tkape
+    -
         Name: Total Commander
         Category: Apps
         Path: TotalCommander.tkape
@@ -32,4 +36,4 @@ Targets:
 # Documentation
 # For those looking to contribute to this list, check here for ideas: https://en.wikipedia.org/wiki/Comparison_of_file_managers.
 # Install one of the applications not covered above and find where useful information is stored. If useful information can be located, make an individual Target for it and place in the appropriate folder. Then, include that Target in the appropriate Compound Target.
-# Use Everything, Directory Monitor Pro (not free), NirSoft's RegistryChangesView, etc to monitor what these applications do to the File System and DOCUMENT!
+# Use Everything, Directory Monitor Pro (not free, but use a trial if you don't want to pay), NirSoft's RegistryChangesView, etc to monitor what these applications do to the File System and DOCUMENT!


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
