### PR TITLE
Add EFCommander, MidnightCommander, TablacusExplorer, SpeedCommander, OneCommander, Update FileExplorerReplacements

### DIFF
--- a/Targets/Apps/EFCommander.tkape
+++ b/Targets/Apps/EFCommander.tkape
@@ -1,0 +1,16 @@
+Description: EF Commander
+Author: Andrew Rathbun
+Version: 1.0
+Id: e94a00dd-3206-4a2c-aa5c-a69f7a09b7b3
+RecreateDirectories: true
+Targets:
+    -
+        Name: EF Commander - .ini File
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\EFSoftware\
+        Comment: "Locates folder where all configuration files reside"
+
+# Documentation
+# http://www.efsoftware.com/cw/e.htm
+# EF Commander is a shareware file manager similar to Total Commander.
+# EFCW.INI will have the history of the left and right panel as well as any FTP servers the user connected to.

--- a/Targets/Apps/MidnightCommander.tkape
+++ b/Targets/Apps/MidnightCommander.tkape
@@ -1,0 +1,16 @@
+Description: Midnight Commander
+Author: Andrew Rathbun
+Version: 1.0
+Id: c02a2310-8ec2-4c0f-8a8a-b20ac0820e46
+RecreateDirectories: true
+Targets:
+    -
+        Name: Midnight Commander -- All Configuation Files
+        Category: Apps
+        Path: C:\Users\%user%\Midnight Commander\
+        Comment: "Locates folder where all configuration files reside"
+
+# Documentation
+# https://midnight-commander.org/
+# Midnight Commander is a free, open course orthodox file manager similar to Norton Commander.
+# This folder is created upon install so it should be where all configuration files resides. I've not done extensive testing on this one due to the DOSness of the application.

--- a/Targets/Apps/OneCommander.tkape
+++ b/Targets/Apps/OneCommander.tkape
@@ -1,0 +1,23 @@
+Description: One Commander
+Author: Andrew Rathbun
+Version: 1.0
+Id: 5b532f4e-f6cb-4d59-bd44-91b9f9d94a54
+RecreateDirectories: true
+Targets:
+    -
+        Name: One Commander - All Configuration Files
+        Category: Apps
+        Path: C:\Users\%user%\OneCommander\
+        Comment: "Locates folder where all configuration files reside"
+    -
+        Name: One Commander - Other Configuration Files
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Apps\2.0\*\*\onec*\
+        Recursive: true
+        Comment: "Locates folder where all configuration files reside"
+
+# Documentation
+# https://onecommander.com/
+# One Commander is a freeware file manager similar to Total Commander.
+# \%user%\OneCommander\Logs\OCLog20210404.txt will have a play by play of user activity, however, it doesn't appear to be as verbose as one would expect. I've yet to see exact folder paths specified within this file in my limited testing.
+# .\%user\OneCommander\Settings\OneCommanderV3.json will have the name of the user's PC.

--- a/Targets/Apps/SpeedCommander.tkape
+++ b/Targets/Apps/SpeedCommander.tkape
@@ -1,0 +1,16 @@
+Description: SpeedCommander
+Author: Andrew Rathbun
+Version: 1.0
+Id: 237f2355-4ae1-4461-812f-2833003aabc3
+RecreateDirectories: true
+Targets:
+    -
+        Name: SpeedCommander - .ini File
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\SpeedProject\SpeedCommander 19\
+        Comment: "Locates folder where all configuration files reside"
+
+# Documentation
+# https://www.speedproject.com/
+# SpeedCommander is a shareware file manager similar to Total Commander.
+# SpeedCommander.xml will have the history of the left and right panel as well as any FTP servers the user connected to.

--- a/Targets/Apps/TablacusExplorer.tkape
+++ b/Targets/Apps/TablacusExplorer.tkape
@@ -1,0 +1,33 @@
+Description: Tablacus Explorer
+Author: Andrew Rathbun
+Version: 1.0
+Id: 0dc0d6c0-3385-4621-886e-0bda8f97cbc4
+RecreateDirectories: true
+Targets:
+    -
+        Name: Tablacus Explorer - remember.xml
+        Category: Logs
+        Path: C:\Users\%user%\AppData\Local\Temp\*\config
+        FileMask: 'remember.xml'
+        Recursive: true
+    -
+        Name: Tablacus Explorer - window.xml
+        Category: Logs
+        Path: C:\Users\%user%\AppData\Local\Temp\*\config
+        FileMask: 'window.xml'
+        Recursive: true
+    -
+        Name: Tablacus Explorer - window1.xml
+        Category: Logs
+        Path: C:\Users\%user%\AppData\Local\Temp\*\config
+        FileMask: 'window1.xml'
+        Recursive: true
+
+# Documentation
+# https://tablacus.github.io/explorer_en.html
+# Tablacus Explorer is a free, open-source orthodox file manager that is completely portable. No installation is needed. Therefore, the registry is not touched nor are there reliable file system locations for artifacts.
+# However, the .\AppData\Local\Temp\ directory may come in handy. I noticed that copies of the XML files in my local Tablacus Explorer folder were located there.
+# My folder path had dtemp-d2fffa101683078-60.dop in place of the asterisk, so I'm guessing that's randomized with each install. As a precaustion, I used an asterisk.
+# Window and Window1.xml will have information regarding to what the user had open in each window at the time.
+# Please note that Tablacus Explorer has an add-on for up to 9 tabs to be open at once.
+# Remember.xml is likely tied to the plugin "Remember folder view settings" that ships with Tablacus Explorer. It can be disabled at any time.

--- a/Targets/Compound/FileExplorerReplacements.tkape
+++ b/Targets/Compound/FileExplorerReplacements.tkape
@@ -1,6 +1,6 @@
 Description: File Explorer Replacements
 Author: Andrew Rathbun
-Version: 1.2
+Version: 1.3
 Id: 8e1cb436-dada-413f-845d-f2ed0823cb3a
 RecreateDirectories: true
 Targets:
@@ -13,17 +13,37 @@ Targets:
         Category: Apps
         Path: DoubleCommander.tkape
     -
+        Name: EF Commander
+        Category: Apps
+        Path: EFCommander.tkape
+    -
         Name: FreeCommander XE
         Category: Apps
         Path: FreeCommander.tkape
+    -
+        Name: Midnight Commander
+        Category: Apps
+        Path: MidnightCommander.tkape
     -
         Name: Multi Commander
         Category: Apps
         Path: MultiCommander.tkape
     -
+        Name: One Commander
+        Category: Apps
+        Path: OneCommander.tkape
+    -
         Name: Q-Dir
         Category: Apps
         Path: Q-Dir.tkape
+    -
+        Name: SpeedCommander
+        Category: Apps
+        Path: SpeedCommander.tkape
+    -
+        Name: Tablacus Explorer
+        Category: Apps
+        Path: TablacusExplorer.tkape
     -
         Name: Total Commander
         Category: Apps
@@ -34,6 +54,6 @@ Targets:
         Path: XYplorer.tkape
 
 # Documentation
-# For those looking to contribute to this list, check here for ideas: https://en.wikipedia.org/wiki/Comparison_of_file_managers.
+# For those looking to contribute to this list, check here for ideas: https://en.wikipedia.org/wiki/Comparison_of_file_managers or https://alternativeto.net/software/total-commander/.
 # Install one of the applications not covered above and find where useful information is stored. If useful information can be located, make an individual Target for it and place in the appropriate folder. Then, include that Target in the appropriate Compound Target.
 # Use Everything, Directory Monitor Pro (not free, but use a trial if you don't want to pay), NirSoft's RegistryChangesView, etc to monitor what these applications do to the File System and DOCUMENT!


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
