### PR TITLE
added additional location for  PST or OST for Outlook 2013 or 2016

### DIFF
--- a/Targets/Apps/OutlookPSTOST.tkape
+++ b/Targets/Apps/OutlookPSTOST.tkape
@@ -24,8 +24,20 @@ Targets:
         Category: Communications
         Path: C:\Users\%user%\AppData\Local\Microsoft\Outlook\
         FileMask: '*.ost'
+    -
+        Name: PST (2013 or 2016)
+        Category: Communications
+        Path: C:\Users\%user%\Documents\Outlook Files\
+        FileMask: '*.pst'
+    -
+        Name: OST (2013 or 2016)
+        Category: Communications
+        Path: C:\Users\%user%\Documents\Outlook Files\
+        FileMask: '*.ost'
+
 
 # Documentation
+# https://support.microsoft.com/en-us/office/introduction-to-outlook-data-files-pst-and-ost-222eaf92-a995-45d9-bde2-f331f60e2790
 # https://www.sans.org/security-resources/posters/windows-forensic-analysis/170/download
 # https://gist.github.com/richaarya/d336fec34c600cc8ab8a51195289c99a
 # https://www.nirsoft.net/outlook_office_software.html


### PR DESCRIPTION
We found that there's an additional location for OSTs and PSTs to be aware of for previous versions of Outlook.

## Description

Additional location of OST and PST 

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ x] I have generated a unique GUID for my Target(s)/Module(s)
- [ x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x ] I have set or updated the version of my Target(s)/Module(s)
- [x ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [x ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
