### PR TITLE
Update ShareX.tkape

### DIFF
--- a/Targets/Apps/ShareX.tkape
+++ b/Targets/Apps/ShareX.tkape
@@ -19,4 +19,5 @@ Targets:
 # I changed the default folder location for where my screenshots, settings, etc were stored but C:\Users\%user%\Documents\ShareX\PersonalPath.cfg still existed and pointed to the location I moved everything over to.
 # Screenshots folder will contain logical copies of all captures by the user typically separated by folder in YYYY-MM format with the logical files residing inside.
 # Within the application's storage folder, there will be a Logs folder with files with a naming convention of ShareX-Log-YYYY-MM.txt. These files are important as they give a literal play-by-play of the user's actions with ShareX.
-# This target captures the contents of everything within the default folder path upon ShareX's installation. Modify the target as needed if. Contact me if you need help with that.
+# This Target captures the contents of everything within the default folder path upon ShareX's installation. Modify the target as needed if. Contact me if you need help with that.
+# UploadersConfig.json will have information regarding FTP/Cloud Storage accounts set up by the user.


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
