### PR TITLE
Adding bitdefender db docs

### DIFF
--- a/Targets/Antivirus/Bitdefender.tkape
+++ b/Targets/Antivirus/Bitdefender.tkape
@@ -1,5 +1,5 @@
 Description: Bitdefender Antivirus Data
-Author: Drew Ervin
+Author: Drew Ervin, Ahmed Elshaer
 Version: 1.1
 Id: e48c32bf-4069-4f79-acac-4ed181fa84c9
 RecreateDirectories: true
@@ -23,4 +23,4 @@ Targets:
         Comment: "Bitdefender SQLite databases"
 
 # Documentation
-# N/A
+# https://anelshaer.medium.com/browsing-history-in-bitdefender-dbs-2d63ba940f92


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
