### PR TITLE
Winpmem source and Commandline update

### DIFF
--- a/Modules/LiveResponse/WinPmem.mkape
+++ b/Modules/LiveResponse/WinPmem.mkape
@@ -3,13 +3,13 @@ Category: Memory
 Author: Eric Capuano
 Version: 3.0
 Id: 1d284835-417b-459e-a396-d228edea3808
-BinaryUrl: https://github.com/Velocidex/c-aff4/releases/download/3.2/winpmem_3.2.exe
-ExportFormat: dmp
+BinaryUrl: https://github.com/Velocidex/WinPmem/releases/download/v4.0.rc1/winpmem_mini_x64_rc2.exe
+ExportFormat: raw
 Processors:
     -
         Executable: winpmem.exe
-        CommandLine: "-o %destinationDirectory%\\memory.dmp --volume_format raw --format raw -dd --logfile %destinationDirectory%\\winpmem.log"
-        ExportFormat: dmp
+        CommandLine: "%destinationDirectory%\\memory.raw"
+        ExportFormat: raw
 
 # Documentation
 # https://winpmem.velocidex.com/


### PR DESCRIPTION
Change the winpmem binaryurl and updated  CommandLine parameters

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
