### PR TITLE
Fix UsrClass.dat KapeResearch Module, Add Amcache.hve KapeResearch Module

### DIFF
--- a/Modules/KapeResearch/KapeResearch_Registry_Amcache.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_Amcache.mkape
@@ -1,0 +1,24 @@
+Description: 'RECmd: Convert Amcache.hve registry hive to JSON for research'
+Category: Registry
+Author: Andrew Rathbun
+Version: 1.0
+Id: b8e15fde-3af7-40ce-86da-b71fb95b3e14
+BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/RegistryExplorer_RECmd.zip
+ExportFormat: json
+FileMask: Amcache.hve
+Processors:
+    -
+        Executable: RECmd\RECmd.exe
+        CommandLine: -f %sourceFile% --kn * --nl false --json %destinationDirectory% --jsonf Amcache.json -q
+        ExportFormat: json
+
+# Documentation
+# https://github.com/EricZimmerman/RECmd
+# https://binaryforay.blogspot.com/2015/05/introducing-recmd.html
+# https://aboutdfir.com/toolsandartifacts/windows/registry-explorer-recmd/
+# https://www.andreafortuna.org/2020/03/04/recmd-command-line-tool-for-windows-registry-analysis/
+# https://www.sans.org/blog/finding-registry-malware-persistence-with-recmd/
+# https://www.youtube.com/watch?v=tk9XsMHzPlM
+# https://www.youtube.com/watch?v=GhCZfCzn2l0
+# Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
+# This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way

--- a/Modules/KapeResearch/KapeResearch_Registry_UsrClass.mkape
+++ b/Modules/KapeResearch/KapeResearch_Registry_UsrClass.mkape
@@ -22,5 +22,3 @@ Processors:
 # https://www.youtube.com/watch?v=GhCZfCzn2l0
 # Note: --nl false replays transaction logs. If you don't want to replay transaction logs, change to --nl true.
 # This module will convert the entire content any registry hives into JSON, which is helpful for viewing all that the hives contain in an easily searchable way
-# You will want to rename the hive to UsrClass_ROOT.json or similar. If you run all of the KapeResearch Modules at the same time, they will write over each other and you'll only end up with a single ROOT.json file
-# UsrClass.dat will have to be done manually. Open the UsrClass.dat in Registry Explorer and use the name of the ROOT key and run this same command with that value in place of ROOT


### PR DESCRIPTION
## Description

Fix UsrClass.dat KapeResearch Module, Add Amcache.hve KapeResearch Module

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
