### PR TITLE
Adding a mkape file for bmc-tools created by ANSSI-FR under Module

### DIFF
--- a/Modules/Misc/bmctools.mkape
+++ b/Modules/Misc/bmctools.mkape
@@ -6,7 +6,6 @@ Id: fcb0083d-11d7-4305-9577-2379cd243bd0
 BinaryUrl: https://github.com/dingtoffee/bmc-tools/blob/master/dist/bmc-tools.exe
 FileMask: "*.bmc"
 ExportFormat: ""
-
 Processors:
     -
         Executable: bmc-tools.exe
@@ -15,4 +14,3 @@ Processors:
 
 # Documentation
 # https://github.com/ANSSI-FR/bmc-tools
-

--- a/Modules/Misc/bmctools.mkape
+++ b/Modules/Misc/bmctools.mkape
@@ -1,0 +1,18 @@
+Description: 'BMC-Tools: RDP Bitmap Cache parser'
+Category: Remote Access
+Author: Elaine Hung
+Version: 1.0
+Id: fcb0083d-11d7-4305-9577-2379cd243bd0
+BinaryUrl: https://github.com/dingtoffee/bmc-tools/blob/master/dist/bmc-tools.exe
+FileMask: "*.bmc"
+ExportFormat: ""
+
+Processors:
+    -
+        Executable: bmc-tools.exe
+        CommandLine: -s %sourceFile% -d %destinationDirectory% -b
+        ExportFormat: ""
+
+# Documentation
+# https://github.com/ANSSI-FR/bmc-tools
+

--- a/Modules/Misc/bmctools.mkape
+++ b/Modules/Misc/bmctools.mkape
@@ -1,6 +1,6 @@
 Description: 'BMC-Tools: RDP Bitmap Cache parser'
 Category: Remote Access
-Author: Elaine Hung
+Author: dingtoffee
 Version: 1.0
 Id: fcb0083d-11d7-4305-9577-2379cd243bd0
 BinaryUrl: https://github.com/dingtoffee/bmc-tools/blob/master/dist/bmc-tools.exe


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X ] I have generated a unique GUID for my Target(s)/Module(s)
- [X ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X ] I have set or updated the version of my Target(s)/Module(s)
- [N/A ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ N/A] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
