### PR TITLE
Update FileSystem Targets to work on mounted VHDX/Image files 

### DIFF
--- a/Targets/Windows/$J.tkape
+++ b/Targets/Windows/$J.tkape
@@ -1,6 +1,6 @@
 Description: $J
-Author: Eric Zimmerman
-Version: 1.0
+Author: Eric Zimmerman and Andrew Rathbun
+Version: 1.1
 Id: 2a9c6f80-250b-42a6-9d29-90cb0a20f7be
 RecreateDirectories: true
 Targets:
@@ -18,6 +18,22 @@ Targets:
         FileMask: $UsnJrnl:$Max
         AlwaysAddToQueue: true
         SaveAsFileName: $Max
+    -
+        Name: $J
+        Category: FileSystem
+        Path: C:\
+        FileMask: $J
+        AlwaysAddToQueue: true
+        SaveAsFileName: $J
+        Comment: "This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed"
+    -
+        Name: $Max
+        Category: FileSystem
+        Path: C:\
+        FileMask: $Max
+        AlwaysAddToQueue: true
+        SaveAsFileName: $Max
+        Comment: "This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Targets are looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed"
 
 # Documentation
 # https://digital-forensics.sans.org/media/DFIR-Command-Line.pdf

--- a/Targets/Windows/$SDS.tkape
+++ b/Targets/Windows/$SDS.tkape
@@ -1,6 +1,6 @@
 Description: $SDS
-Author: Eric Zimmerman
-Version: 1.0
+Author: Eric Zimmerman and Andrew Rathbun
+Version: 1.1
 Id: 72d56db2-b8da-4830-a2e7-37437c90e18f
 RecreateDirectories: true
 Targets:
@@ -11,6 +11,14 @@ Targets:
         FileMask: $Secure:$SDS
         AlwaysAddToQueue: true
         SaveAsFileName: $Secure_$SDS
+    -
+        Name: $SDS
+        Category: FileSystem
+        Path: C:\
+        FileMask: $Secure_$SDS
+        AlwaysAddToQueue: true
+        SaveAsFileName: $Secure_$SDS
+        Comment: "This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Target is looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed"
 
 # Documentation
 # https://digital-forensics.sans.org/media/DFIR-Command-Line.pdf

--- a/Targets/Windows/$T.tkape
+++ b/Targets/Windows/$T.tkape
@@ -1,6 +1,6 @@
 Description: $T
-Author: Eric Zimmerman
-Version: 1.0
+Author: Eric Zimmerman and Andrew Rathbun
+Version: 1.1
 Id: 8c568aa0-9a67-4035-9720-1423770bc29a
 RecreateDirectories: true
 Targets:
@@ -11,6 +11,15 @@ Targets:
         FileMask: $Tops:$T
         AlwaysAddToQueue: true
         SaveAsFileName: $T
+    -
+        Name: $T
+        Category: FileSystem
+        Path: C:\$Extend\$RmMetadata\$TxfLog\
+        FileMask: $T
+        AlwaysAddToQueue: true
+        SaveAsFileName: $T
+        Comment: "This is for the use case when you're running this Target against a mounted VHDX with these files already pulled from a live system. The above Target is looking for the files as an ADS whereas once they are already pulled they no longer match the ADS criteria and therefore are missed"
+
 
 # Documentation
 # TxF Old Page Stream (TOPS) file Used to store data that has been overwritten inside a currently active transaction


### PR DESCRIPTION
## Description

Intended for when these files are part of a VHDX that has already been pulled and the end user wants to run Targets against the package to effectively move those files to another location where their Module output will reside as well. 

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
