### PR TITLE
Add new mRemoteNG Target, update RemoteAdmin Compound Target

### DIFF
--- a/Targets/Apps/mRemoteNG.tkape
+++ b/Targets/Apps/mRemoteNG.tkape
@@ -1,0 +1,32 @@
+Description: mRemoteNG
+Author: Markus Einarsson (@einarssonm)
+Version: 1.0
+Id: 486c2b29-ae39-4418-8fb4-2d855e9387f9
+RecreateDirectories: true
+Targets:
+    -
+        Name: mRemoteNG Logs
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Roaming\mRemoteNG\
+        FileMask: mRemoteNG.log
+        Comment: Contains log entries for remote connections
+    -
+        Name: mRemoteNG Connection Configuration and Backups
+        Category: Communications
+        Path: C:\Users\%user%\AppData\Roaming\mRemoteNG\
+        FileMask: confCons.xml*
+        Comment: Contains connection config, often with obfuscated credentials
+    -
+        Name: mRemoteNG Program Settings
+        Category: Communications
+        Path: C:\Users\%user%\AppData\*\mRemoteNG\
+        Recursive: true
+        FileMask: user.config
+        Comment: Contains user-specific program settings
+
+# Documentation
+# https://mremoteng.org/
+# https://vk9-sec.com/exploiting-mremoteng/
+# mRemoteNG is an open source, multi-protocol, remote connections manager for Windows.
+# It handles connections for RDP, VNC, SSH, Telnet, rlogin and other protocols.
+# The stored credentials are encrypted with a static key and base64 encoded.

--- a/Targets/Compound/RemoteAdmin.tkape
+++ b/Targets/Compound/RemoteAdmin.tkape
@@ -1,6 +1,6 @@
 Description: Composite target for files related to remote administration tools
 Author: Drew Ervin, Mathias Frank, Andrew Rathbun
-Version: 1.4
+Version: 1.5
 Id: 31cf5a4e-c44c-4457-b11f-74dca73e141b
 RecreateDirectories: true
 Targets:
@@ -24,6 +24,10 @@ Targets:
         Name: LogMeIn
         Category: ApplicationLogs
         Path: LogMeIn.tkape
+    -
+        Name: mRemoteNG
+        Category: ApplicationLogs
+        Path: mRemoteNG.tkape
     -
         Name: Radmin
         Category: ApplicationLogs


### PR DESCRIPTION
## Description

Adds target definitions for mRemoteNG, to collect logs and config for remote connections.

This is my first ever PR for a public repo, and there is more in the pipeline. I'm trying to get a head start before the expected wave of submissions after the upcoming DFIR Summit presentation. ;)

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have generated a unique GUID for my Target(s)/Module(s)
- [X] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [X] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
