### PR TITLE
Add PortProxy netsh live response module

### DIFF
--- a/Modules/LiveResponse/netsh-portproxy.mkape
+++ b/Modules/LiveResponse/netsh-portproxy.mkape
@@ -1,0 +1,17 @@
+Description: PortProxy configuration
+Category: LiveResponse
+Author: Andreas Hunkeler (@Karneades)
+Version: 1.0
+Id: a7e6344e-2680-447f-223e-e79ad3aa0e65
+ExportFormat: txt
+Processors:
+    -
+        Executable: C:\Windows\System32\netsh.exe
+        CommandLine: interface portproxy show all
+        ExportFormat: txt
+        ExportFile: netsh_portproxy.txt
+
+# Documentation
+#   https://www.fireeye.com/blog/threat-research/2019/01/bypassing-network-restrictions-through-rdp-tunneling.html
+#   https://adepts.of0x.cc/netsh-portproxy-code/
+#   https://www.dfirnotes.net/portproxy_detection/


### PR DESCRIPTION
## Description

Add new LR module for reading the PortProxy configuration through netsh.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!