### PR TITLE
Create KAPE Module and Compound Module Guides and Templates

### DIFF
--- a/Modules/CompoundModuleGuide.guide
+++ b/Modules/CompoundModuleGuide.guide
@@ -1,0 +1,36 @@
+Description: Name of application/artifact here # Required, this should be higher level for Compound Targets/Modules
+Category: Misc # Required, this value will be the name of the folder where the parsed Module output is stored
+Author: FirstName LastName # Make sure you get credit for your work
+Version: 1.0 # Required, iterate as necessary
+Id: 62308e3b-5e67-4612-b472-24e0c85fccfe # Required, unique GUID is required for every KAPE Target/Module
+BinaryUrl: https://url.goes.here.com # Required
+ExportFormat: csv # Required
+FileMask: FileName.exe # For a Compound Module, this shouldn't matter as each individual Module will have its own filemask that the Module will be looking for when executing commands listed within the Module
+Processors:
+    -
+        Executable: Module1.mkape # Make sure this matches the exact filename of the Module you want this Compound Module to call
+        CommandLine: "" # No need to change this, again, each Module you're calling has their own values for this field
+        ExportFormat: "" # Same as above
+    -
+        Executable: Module2.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module3.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module4.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module5.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module6.mkape
+        CommandLine: ""
+        ExportFormat: ""
+
+# Documentation
+# For Compound Modules, there's no real need to add all the documentation from each individual Module here. It's duplicative and unnecessary.

--- a/Modules/CompoundModuleTemplate.template
+++ b/Modules/CompoundModuleTemplate.template
@@ -1,0 +1,36 @@
+Description: Name of application/artifact here
+Category: Misc
+Author: FirstName LastName
+Version: 1.0
+Id: b61ccd7a-3f8a-4347-b5ac-21486aaa76c4
+BinaryUrl: https://url.goes.here.com
+ExportFormat: csv
+FileMask: FileName.exe
+Processors:
+    -
+        Executable: Module1.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module2.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module3.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module4.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module5.mkape
+        CommandLine: ""
+        ExportFormat: ""
+    -
+        Executable: Module6.mkape
+        CommandLine: ""
+        ExportFormat: ""
+
+# Documentation
+# N/A if no Documentation present. End with new line. Be sure to check out the CompoundModuleGuide.guide for more information!

--- a/Modules/ModuleGuide.guide
+++ b/Modules/ModuleGuide.guide
@@ -1,0 +1,29 @@
+Description: Name of application/artifact here # Required
+Category: Misc # Required, this value will be the name of the folder where the parsed Module output is stored
+Author: FirstName LastName # Make sure you get credit for your work
+Version: 1.0 # Required, iterate as necessary
+Id: 0256a455-1248-4e30-8175-727679189ddd # Required, unique GUID is required for every KAPE Target/Module
+BinaryUrl: https://url.goes.here.com # Required
+ExportFormat: csv # Required, this is the default ExportFormat in the instance the user chooses a format that is not listed below, or simply chooses Default within gkape
+WaitTimeout: 0 # Optional, this specifies the number of minutes KAPE should wait for a Module to finish
+FileMask: FileName.exe # You can list file.exe here or do something similar to this using RegEx: regex:(2019|DSC|Log).+\.(jpg|txt)
+Processors:
+    -
+        Executable: Folder\binary.exe # This needs to match the exact name of the binary you're calling and, ideally, the name of the binary listed in BinaryUrl above
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% # This command will need to reflect the ExportFormat listed below. KAPE will execute this command when the user chooses CSV, for example
+        ExportFormat: csv # This needs to match the format the command above is exporting
+    -
+        Executable: Folder\binary.exe # Please note, this is effectively pointing to .\KAPE\Modules\bin\* where * is whatever you put in the Executable field. If you have a binary that is within a folder, you're going to want to make sure your Executable field looks something like this: Folder\binary.exe
+        CommandLine: -d %sourceDirectory% --xml %destinationDirectory% # https://ericzimmerman.github.io/KapeDocs/#!Pages\2.2-Modules.md#CommandLine is a great resource for creating command lines for Modules
+        ExportFormat: xml
+    -
+        Executable: Folder\binary.exe # If your binary is sitting at the root of .\KAPE\Modules\bin, then just list binary.exe here
+        CommandLine: -d %sourceDirectory% --json %destinationDirectory%
+        ExportFormat: json
+
+# Documentation
+# https://ericzimmerman.github.io/KapeDocs/#!Pages\2.2-Modules.md
+# Include any and all documentation for your module, if any. If none, please include N/A instead. N/A is standard among all Targets/Modules without any documentation present and it makes it easy for one to search across all Targets/Modules that need documentation to be added.
+# Be sure to follow the steps within the Pull Request template to ensure there are no syntax errors prior to doing to Pull Request!
+# If there are any questions, just make an Issue on the KapeFiles repository and we'll get it figured out.
+# Please end all Modules with a blank new line below your last # line under Documentation. AKA hit enter once and save prior to doing a PR.

--- a/Modules/ModuleTemplate.template
+++ b/Modules/ModuleTemplate.template
@@ -1,0 +1,24 @@
+Description: Name of application/artifact here
+Category: Misc
+Author: FirstName LastName
+Version: 1.0
+Id: a2231a4c-3bdf-4254-a2ab-06021789d1b0
+BinaryUrl: https://url.goes.here.com
+ExportFormat: csv
+FileMask: FileName.exe
+Processors:
+    -
+        Executable: Folder\binary.exe
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory%
+        ExportFormat: csv
+    -
+        Executable: Folder\binary.exe
+        CommandLine: -d %sourceDirectory% --xml %destinationDirectory%
+        ExportFormat: xml
+    -
+        Executable: Folder\binary.exe
+        CommandLine: -d %sourceDirectory% --json %destinationDirectory%
+        ExportFormat: json
+
+# Documentation
+# N/A if no Documentation present. End with new line. Be sure to check out the ModuleGuide.guide for more information!


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [x] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [x] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
