### PR TITLE
Remove duplicate net file section in NetSystemInfo compound

### DIFF
--- a/Modules/Compound/LiveResponse_NetSystemInfo.mkape
+++ b/Modules/Compound/LiveResponse_NetSystemInfo.mkape
@@ -26,10 +26,6 @@ Processors:
         CommandLine: ""
         ExportFormat: ""
     -
-        Executable: Windows_Net_File.mkape
-        CommandLine: ""
-        ExportFormat: ""
-    -
         Executable: Windows_Net_Session.mkape
         CommandLine: ""
         ExportFormat: ""


### PR DESCRIPTION
Remove duplicate net file section in NetSystemInfo compound. Didn't update the version because it doesn't change the behavior.
