### PR TITLE
Add more verbose timestamps to AmcacheParser, AppCompatCacheParser, JLECmd, and LECmd Modules

### DIFF
--- a/Modules/EZTools/AmcacheParser.mkape
+++ b/Modules/EZTools/AmcacheParser.mkape
@@ -1,7 +1,7 @@
 Description: 'AmcacheParser: extract program execution information'
 Category: ProgramExecution
 Author: Eric Zimmerman
-Version: 1.0
+Version: 1.1
 Id: 4190c518-524f-4623-8038-a014784c018c
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/AmcacheParser.zip
 ExportFormat: csv
@@ -9,7 +9,7 @@ FileMask: Amcache.hve
 Processors:
     -
         Executable: AmcacheParser.exe
-        CommandLine: -f %sourceFile% --csv %destinationDirectory% -i
+        CommandLine: -f %sourceFile% --csv %destinationDirectory% -i --mp
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/AppCompatCacheParser.mkape
+++ b/Modules/EZTools/AppCompatCacheParser.mkape
@@ -1,7 +1,7 @@
 Description: 'AppCompatCacheParser: extract AppCompatCache (shimcache) information'
 Category: ProgramExecution
 Author: Eric Zimmerman
-Version: 1.0
+Version: 1.1
 Id: e5e0ffa8-fe3e-4196-ac5a-d21cbeb879c2
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/AppCompatCacheParser.zip
 ExportFormat: csv
@@ -9,7 +9,7 @@ FileMask: SYSTEM
 Processors:
     -
         Executable: AppCompatCacheParser.exe
-        CommandLine: -f %sourceFile% --csv %destinationDirectory%
+        CommandLine: -f %sourceFile% --csv %destinationDirectory% --mp
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/JLECmd.mkape
+++ b/Modules/EZTools/JLECmd.mkape
@@ -8,15 +8,15 @@ ExportFormat: csv
 Processors:
     -
         Executable: JLECmd.exe
-        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% -q --mp
         ExportFormat: csv
     -
         Executable: JLECmd.exe
-        CommandLine: -d %sourceDirectory% --html %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --html %destinationDirectory% -q --mp
         ExportFormat: html
     -
         Executable: JLECmd.exe
-        CommandLine: -d %sourceDirectory% --json %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --json %destinationDirectory% -q --mp
         ExportFormat: json
 
 # Documentation

--- a/Modules/EZTools/JLECmd.mkape
+++ b/Modules/EZTools/JLECmd.mkape
@@ -1,7 +1,7 @@
 Description: 'JLECmd: process jumplist files'
 Category: FileFolderAccess
 Author: Eric Zimmerman
-Version: 1.0
+Version: 1.1
 Id: 81fe4336-eb10-4733-a770-cb57ec9bd108
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/JLECmd.zip
 ExportFormat: csv

--- a/Modules/EZTools/LECmd.mkape
+++ b/Modules/EZTools/LECmd.mkape
@@ -1,22 +1,22 @@
 Description: 'LECmd: process .lnk files'
 Category: FileFolderAccess
 Author: Eric Zimmerman
-Version: 1.0
+Version: 1.1
 Id: 1b66f0e2-2ccf-449c-ae02-a1b3dc59df08
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/LECmd.zip
 ExportFormat: csv
 Processors:
     -
         Executable: LECmd.exe
-        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --csv %destinationDirectory% -q --mp
         ExportFormat: csv
     -
         Executable: LECmd.exe
-        CommandLine: -d %sourceDirectory% --html %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --html %destinationDirectory% -q --mp
         ExportFormat: html
     -
         Executable: LECmd.exe
-        CommandLine: -d %sourceDirectory% --json %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --json %destinationDirectory% -q --mp
         ExportFormat: json
 
 # Documentation


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Target(s)/Module(s)
- [ ] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [ ] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
