### PR TITLE
Create PowerShell_MFTECmd_$J-$MFTParsing.mkape

### DIFF
--- a/Modules/Apps/GitHub/PowerShell_MFTECmd_$J-$MFTParsing.mkape
+++ b/Modules/Apps/GitHub/PowerShell_MFTECmd_$J-$MFTParsing.mkape
@@ -1,0 +1,18 @@
+Description: MFTECmd - Parse $J and $MFT together to produce CSV output with ParentPath populated in $J CSV
+Category: FileSystem
+Author: Andrew Rathbun
+Version: 1.0
+Id: ac0660c3-4eb2-4dee-ad90-5ef782b94750
+BinaryUrl: https://github.com/AndrewRathbun/DFIRPowerShellScripts/blob/main/MFTECmd%24J%24MFTParser.ps1
+ExportFormat: csv
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: "& '%kapeDirectory%\\Modules\\bin\\MFTECmd$J$MFTParser.ps1' -TargetsFolder %sourceDirectory% -OutputFolder %destinationDirectory%"
+        ExportFormat: csv
+
+# Documentation
+# https://github.com/AndrewRathbun/DFIRPowerShellScripts/blob/main/MFTECmd%24J%24MFTParser.ps1
+# Use this when there's a $J and $MFT present. This script will search for the $J and $MFT and parse them with the MFTECmd executable that resides in .\KAPE\Modules\bin
+# The main reason for this script's existence is because a KAPE Module cannot have 2 file masks (one for $J and another for $MFT) so this script serves as the workaround for that scenario
+# To use this properly, point to a parent folder where somewhere in a child folder there exists a $J and $MFT, ideally from the same system!


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [x] I have generated a unique `GUID` for my Target(s)/Module(s)
- [x] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [x] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
