### PR TITLE
Update hayabusa and THOR-lite

### DIFF
--- a/Modules/Apps/GitHub/hayabusa.mkape
+++ b/Modules/Apps/GitHub/hayabusa.mkape
@@ -1,13 +1,13 @@
 Description: hayabusa
 Category: EventLogs
 Author: Georg Lauenstein
-Version: 1.0
+Version: 1.1
 Id: 9696412c-c973-4fd4-a426-06318011b8ba
 ExportFormat: csv
 Processors:
     -
         Executable: hayabusa\hayabusa.exe
-        CommandLine: -d %sourceDirectory% --utc --quiet -o %destinationDirectory%\hayabusa.csv
+        CommandLine: --live-analysis --min-level low --utc --quiet --rfc-2822 -o %destinationDirectory%\hayabusa.csv
         ExportFormat: csv
 
 # Documentation

--- a/Modules/Apps/Thor-Lite_LiveResponse.mkape
+++ b/Modules/Apps/Thor-Lite_LiveResponse.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: thor-lite\thor64-lite.exe
-        CommandLine: "--quick --nothordb --processintegrity -o :hostname:\_:time:.csv -e %destinationDirectory%\\THOR"
+        CommandLine: "--quick --nothordb --processintegrity --lookback 30 --showdeleted -o :hostname:\_:time:.csv -e %destinationDirectory%\\THOR"
         ExportFormat: csv
 
 # Docuemntation
@@ -23,3 +23,4 @@ Processors:
 #
 # Currently configured to run "--quick" option which "selects the most relevant file paths only"
 # Remove "--quick" for a full scan which will take much longer. (~2min versus 23min on test system)
+# for Filescan use "Thor-Lite_Scan.mkape"


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header

Thank you for your submission and for contributing to the DFIR community!

**hayabusa:**
due to update
`--live-analysis ` -> 'Analyze the local C:\Windows\System32\winevt\Logs folder (Windows Only. Administrator privileges required.)'
`--rfc-2822 `-> Output date and time in RFC 2822 format. (Example: Mon, 07 Aug 2006 12:34:56 -0600)

**THOR-lite:**
`--lookback 30 `-> Specify how many past days shall be analyzed. Event log entries from before this point will be ignored
`--showdeleted`  -> Show deleted files found in the MFT as 'info' messages.

