### PR TITLE
Add Nirsoft TurnedOnTimesViewtime module (System.evtx parsing for tur…

### DIFF
--- a/Modules/Apps/NirSoft/NirSoft_TurnedOnTimesView.mkape
+++ b/Modules/Apps/NirSoft/NirSoft_TurnedOnTimesView.mkape
@@ -1,0 +1,17 @@
+Description: 'Uses Nirsoft TurnedOnTimesViewtime to determine time ranges the system was turned on'
+Category: EventLogs
+Author: Thomas DIOT
+Version: 1.0
+Id: 95549abe-f13a-4c8c-bccb-8dbb7fdbe83a
+BinaryUrl: https://www.nirsoft.net/utils/turnedontimesview.zip
+ExportFormat: csv
+Processors:
+    -
+        Executable: turnedontimesview\TurnedOnTimesView.exe
+        CommandLine: /RunAsAdmin /Source 3 /ExternalFolder %sourceDirectory%\Windows\System32\winevt\Logs /scomma %destinationDirectory%\TurnedOnTimes.csv
+        ExportFormat: csv
+
+# Documentation
+# https://www.nirsoft.net/utils/computer_turned_on_times.html
+# TurnedOnTimesViewtime execution may produce an empty CSV output.
+# In such case, the "New Event Log API" should be turned off ("UseNewEventLogAPI=0" in the "TurnedOnTimesView.cfg" config file).


### PR DESCRIPTION
## Description

Add a module for processing `System.evtx` to determine the time ranges the system was up using Nirsoft's `TurnedOnTimesViewtime` utility. Produces a CSV output.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format