### PR TITLE
Update MFTECmd_$J module to process $UsnJrnl$J files

### DIFF
--- a/Modules/EZTools/MFTECmd/MFTECmd_$J.mkape
+++ b/Modules/EZTools/MFTECmd/MFTECmd_$J.mkape
@@ -1,11 +1,11 @@
-Description: 'MFTECmd: process $J files'
+Description: 'MFTECmd: process $J / $UsnJrnl$J files'
 Category: FileSystem
-Author: Eric Zimmerman
-Version: 1.0
+Author: Eric Zimmerman, Thomas DIOT
+Version: 1.1
 Id: 5ef67a6b-5895-46bb-af2a-3339a3227e25
 BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
 ExportFormat: csv
-FileMask: $J
+FileMask: regex:(\$UsnJrnl)?\$J
 Processors:
     -
         Executable: MFTECmd.exe
@@ -22,3 +22,4 @@ Processors:
 # https://binaryforay.blogspot.com/2018/06/introducing-mftecmd.html
 # https://aboutdfir.com/toolsandartifacts/windows/mft-explorer-mftecmd/
 # https://www.youtube.com/watch?v=GhCZfCzn2l0
+# KAPE collects the UsnJrnl artefact as "$J" while some tools, such as Velociraptor, collect it as "$UsnJrnl$J".


### PR DESCRIPTION
## Description

As previously discussed in #636, update the `MFTECmd_$J` module with a regex `FileMask` (`regex:(\$UsnJrnl)?\$J`) to process `$UsnJrnl$J` files (in addition to `J$` files).

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format