### PR TITLE
Bugfix 668 - Bug documentation - Spaces in MRC

### DIFF
--- a/Modules/Apps/MagnetForensics_RAMCapture.mkape
+++ b/Modules/Apps/MagnetForensics_RAMCapture.mkape
@@ -21,3 +21,7 @@ Processors:
 #
 # Example usage:
 # kape.exe --tsource C: --tdest E:\Triage\ --target KapeTriage --vhdx triage --mdest E:\Triage\Memory --module MagnetRamCapture
+#
+# Bug: Spaces in the destinationDirectory will cause MRC to fail to collect/crash.
+#       Workarounds include modifying this module to include the destination path manually (with quotes) or
+#       avoid spaces in the mdest parameter

--- a/Modules/Apps/MagnetForensics_RAMCapture.mkape
+++ b/Modules/Apps/MagnetForensics_RAMCapture.mkape
@@ -1,7 +1,7 @@
 Description: Magnet RAM Capture Memory Acquisition
 Category: Memory
 Author: Doug Metz
-Version: 1.0
+Version: 1.1
 Id: 23a35c17-15a8-4d7e-9029-083bc70bd4ef
 BinaryUrl: https://support.magnetforensics.com/
 ExportFormat: raw

--- a/Modules/Apps/MagnetForensics_RAMCapture.mkape
+++ b/Modules/Apps/MagnetForensics_RAMCapture.mkape
@@ -8,7 +8,7 @@ ExportFormat: raw
 Processors:
     -
         Executable: MRC.exe
-        CommandLine: "/accepteula /go %destinationDirectory%\\memory.raw /silent"
+        CommandLine: "/accepteula /go %destinationDirectory%\memory.raw /silent"
         ExportFormat: raw
 
 # Documentation

--- a/Modules/Apps/MagnetForensics_RAMCapture.mkape
+++ b/Modules/Apps/MagnetForensics_RAMCapture.mkape
@@ -8,7 +8,7 @@ ExportFormat: raw
 Processors:
     -
         Executable: MRC.exe
-        CommandLine: "/accepteula /go %destinationDirectory%\memory.raw /silent"
+        CommandLine: "/accepteula /go %destinationDirectory%\\memory.raw /silent"
         ExportFormat: raw
 
 # Documentation

--- a/Modules/Apps/MagnetForensics_RAMCapture.mkape
+++ b/Modules/Apps/MagnetForensics_RAMCapture.mkape
@@ -23,5 +23,4 @@ Processors:
 # kape.exe --tsource C: --tdest E:\Triage\ --target KapeTriage --vhdx triage --mdest E:\Triage\Memory --module MagnetRamCapture
 #
 # Bug: Spaces in the destinationDirectory will cause MRC to fail to collect/crash.
-#       Workarounds include modifying this module to include the destination path manually (with quotes) or
-#       avoid spaces in the mdest parameter
+# Workarounds include modifying this module to include the destination path manually (with quotes) or avoid spaces in the mdest parameter


### PR DESCRIPTION
## Description
Add additional comment/context around issues with space in the destination path for MRC module.
Removes an extra `\` from the command line and bump version number