### PR TITLE
remove `-q` switch from RECmd Modules

### DIFF
--- a/Modules/EZTools/RECmd/RECmd_AllRegExecutablesFoundOrRun.mkape
+++ b/Modules/EZTools/RECmd/RECmd_AllRegExecutablesFoundOrRun.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\AllRegExecutablesFoundOrRun.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\AllRegExecutablesFoundOrRun.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_BCDBootVolume.mkape
+++ b/Modules/EZTools/RECmd/RECmd_BCDBootVolume.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\BCDBootVolume.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\BCDBootVolume.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_BasicSystemInfo.mkape
+++ b/Modules/EZTools/RECmd/RECmd_BasicSystemInfo.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\BasicSystemInfo.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\BasicSystemInfo.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_InstalledSoftware.mkape
+++ b/Modules/EZTools/RECmd/RECmd_InstalledSoftware.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\InstalledSoftware.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\InstalledSoftware.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_Kroll.mkape
+++ b/Modules/EZTools/RECmd/RECmd_Kroll.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\Kroll_Batch.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\Kroll_Batch.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_RECmd_Batch_MC.mkape
+++ b/Modules/EZTools/RECmd/RECmd_RECmd_Batch_MC.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\RECmd_Batch_MC.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\RECmd_Batch_MC.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_RegistryASEPs.mkape
+++ b/Modules/EZTools/RECmd/RECmd_RegistryASEPs.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\RegistryASEPs.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\RegistryASEPs.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_SoftwareASEPs.mkape
+++ b/Modules/EZTools/RECmd/RECmd_SoftwareASEPs.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\SoftwareASEPs.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\SoftwareASEPs.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_SoftwareClassesASEPs.mkape
+++ b/Modules/EZTools/RECmd/RECmd_SoftwareClassesASEPs.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\SoftwareClassesASEPs.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\SoftwareClassesASEPs.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_SoftwareWoW6432ASEPs.mkape
+++ b/Modules/EZTools/RECmd/RECmd_SoftwareWoW6432ASEPs.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\SoftwareWoW6432ASEPs.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\SoftwareWoW6432ASEPs.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_SystemASEPs.mkape
+++ b/Modules/EZTools/RECmd/RECmd_SystemASEPs.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\SystemASEPs.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\SystemASEPs.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_UserActivity.mkape
+++ b/Modules/EZTools/RECmd/RECmd_UserActivity.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\UserActivity.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\UserActivity.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation

--- a/Modules/EZTools/RECmd/RECmd_UserClassesASEPs.mkape
+++ b/Modules/EZTools/RECmd/RECmd_UserClassesASEPs.mkape
@@ -8,7 +8,7 @@ ExportFormat: csv
 Processors:
     -
         Executable: RECmd\RECmd.exe
-        CommandLine: -d %sourceDirectory% --bn BatchExamples\UserClassesASEPs.reb --nl false --csv %destinationDirectory% -q
+        CommandLine: -d %sourceDirectory% --bn BatchExamples\UserClassesASEPs.reb --nl false --csv %destinationDirectory%
         ExportFormat: csv
 
 # Documentation


### PR DESCRIPTION
## Description

`-q` switch is being removed from RECmd since it isn't working. 

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Target(s)/Module(s)
- [ ] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [ ] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
