### PR TITLE
Update 'CombinedLogs' path

### DIFF
--- a/Targets/Compound/!SANS_Triage.tkape
+++ b/Targets/Compound/!SANS_Triage.tkape
@@ -1,6 +1,6 @@
 Description: SANS Triage Collection
 Author: Mark Hallman
-Version: 1.2
+Version: 1.3
 Id: 1bfbd59d-6c58-4eeb-9da7-1d9612b79964
 RecreateDirectories: true
 Targets:
@@ -15,7 +15,7 @@ Targets:
     -
         Name: CombinedLogs
         Category: WindowsLogs
-        Path: EventLogs.tkape
+        Path: CombinedLogs.tkape
     -
         Name: EvidenceOfExecution
         Category: EvidenceOfExecution


### PR DESCRIPTION
## Description

When this was 'Redesigned to use compound targets', in commit f8117375e9c370d350500b622292844bd3e26400, I believe the path for 'CombinedLogs' was incorrectly updated since it was not actually pointed to a compound target and targets like 'PowerShell Console Log' and 'USBDevicesLogs' are no longer included when the previously were.

## Checklist:

- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format