### PR TITLE
Winlogbeat module to parse EVTX to JSON

### DIFF
--- a/Modules/Apps/Winlogbeat_ALL.mkape
+++ b/Modules/Apps/Winlogbeat_ALL.mkape
@@ -1,0 +1,18 @@
+Description: Winlogbeat - Parse all EVTX files (and all their events) to JSON.
+Category: EventLogs
+Author: Thomas DIOT (Qazeer)
+Version: 1.0
+Id: a059c70b-2615-47ce-a45c-75a377eb4fc7
+BinaryUrl: https://www.elastic.co/fr/downloads/beats/winlogbeat
+ExportFormat: json
+FileMask: "*.evtx"
+Processors:
+    -
+        Executable: Winlogbeat\winlogbeat.exe
+        CommandLine: -e -c "%kapeDirectory%\Modules\bin\Winlogbeat\Winlogbeat_Windows_single_EVTX_to_JSON.yml" -E EVTX_FILE=%sourceFile% -E OUTPUT_FOLDER="%destinationDirectory%"
+        ExportFormat: json
+
+# Documentation
+# Uses Winlogbeat to parse EVTX to JSON: https://www.elastic.co/guide/en/beats/winlogbeat/current/index.html
+# Parses EVTX file one by one, due to limitation in the way files can be specified to Winlogbeat. 
+# The "Winlogbeat_Windows_single_EVTX_to_JSON.yml" configuration file can be retrieved from: https://gist.github.com/Qazeer/48e5895a958b32c223e6d0e92e2182ac


### PR DESCRIPTION
## Description

Add a module to execute `Winlogbeat` to parse EVTX files to JSON, with more advanced formatting than what can be achieved with `EvtxECmd` but with speed as a trade-off.

The EVTX files are parsed one-by-one, due to limitation in the way files can be specified to `Winlogbeat`, which is far from perfect and has rather poor performance (but works properly).

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
