### PR TITLE
Fix LogParser_SMBServerAnonymousLogons module

### DIFF
--- a/Modules/Apps/LogParser/LogParser_SMBServerAnonymousLogons.mkape
+++ b/Modules/Apps/LogParser/LogParser_SMBServerAnonymousLogons.mkape
@@ -1,19 +1,17 @@
 Description: LogParser Microsoft-Windows-SMBServer-Security event 551
 Category: RemoteAccess
-Author: Hadar Yudovich
-Version: 1.0
+Author: Hadar Yudovich, Thomas DIOT (Qazeer)
+Version: 1.1
 Id: 7f4fed47-cd92-4a94-a2c0-b937ea218bc8
 BinaryUrl: https://www.microsoft.com/en-us/download/confirmation.aspx?id=24659
 ExportFormat: csv
-FileMask: Microsoft-Windows-SMBServer%4Security.evtx
+FileMask: Microsoft-Windows-SMBServer*Security.evtx
 Processors:
     -
         Executable: LogParser.exe
-        CommandLine: -stats:OFF -i:EVT "SELECT TO_UTCTIME(TimeGenerated) AS Date, EventID, 'Client attempted to access SMB via an anonymous logon.' AS Description, EXTRACT_TOKEN(Strings,8,'|') AS UserName,  EXTRACT_TOKEN(Strings,10,'|') AS ClientName INTO '%destinationDirectory%\logparser-SMBServer-Anonymous-Logon.csv' FROM '%sourceDirectory%\Microsoft-Windows-SMBServer%4Security.evtx' WHERE EventID=551" -filemode:0
+        CommandLine: -stats:OFF -i:EVT "SELECT TO_UTCTIME(TimeGenerated) AS Date, EventID, 'Client attempted to access SMB via an anonymous logon.' AS Description, EXTRACT_TOKEN(Strings,8,'|') AS UserName,  EXTRACT_TOKEN(Strings,10,'|') AS ClientName INTO '%destinationDirectory%\logparser-SMBServer-Anonymous-Logon.csv' FROM '%sourceFile%' WHERE EventID=551" -filemode:0
         ExportFormat: csv
 
 # Documentation
 # Uses Microsoft Log Parser
 # https://www.microsoft.com/en-us/download/confirmation.aspx?id=24659
-# In CommandLine, point sourceDirectory to evtx logs folder
-# Example: C:\Windows\System32\winevt\logs


### PR DESCRIPTION
## Description

Fixes the LogParser_SMBServerAnonymousLogons by changing the `filemask` and replacing `%sourceDirectory%` by `%sourceFile%`.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
