### PR TITLE
Module SMB Mapping

### DIFF
--- a/Modules/Windows/Powershell_SMBMapping.mkape
+++ b/Modules/Windows/Powershell_SMBMapping.mkape
@@ -1,0 +1,14 @@
+Description: Retrieves the Server Message Block (SMB) client directory mappings. It replaces the command net use.
+Category: LiveResponse
+Author: Vito Alfano
+Version: 1.0
+Id: 36092684-5d40-4159-baed-822b7eaaf0a0
+ExportFormat: csv
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: -Command "Get-SMBMapping | Select LocalPath, RemotePath, Status  | Export-Csv -Path %destinationDirectory%\Net_Use.csv -NoTypeInformation "
+        ExportFormat: csv
+
+# Documentation
+# https://learn.microsoft.com/en-us/powershell/module/smbshare/get-smbmapping?view=windowsserver2022-ps


### PR DESCRIPTION
Retrieves the Server Message Block (SMB) client directory mappings. It replaces the command net use

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
