### PR TITLE
Update all Hayabusa modules due to new Version with syntax change

### DIFF
--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_EventStatistics.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_EventStatistics.mkape
@@ -1,22 +1,20 @@
 Description: Hayabusa a timeline generator for Windows event logs - Event Statistics
 Category: EventLogs
-Author: Georg Lauenstein
-Version: 1.1
+Author: Georg Lauenstein (sure[secure])
+Version: 1.2
 Id: f3fb3648-1ccb-458c-80e2-261818803bda
 BinaryUrl: https://github.com/Yamato-Security/hayabusa/releases
 ExportFormat: csv
 Processors:
     -
         Executable: hayabusa\hayabusa.exe
-        CommandLine: --live-analysis -s
+        CommandLine: metrics -d %sourceDirectory%  -o %destinationDirectory%\hayabusa_statistics.csv
         ExportFormat: csv
-        ExportFile: hayabusa_statistics.csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder
 # Place "zip archive" file into "Modules\bin\hayabusa" and unpack
 # rename the hayabusa executable to hayabusa.exe
 # You can delete all except: "config"; "rules" and the "hayabusa.exe"
-# Check version with: hayabusa.exe --version
-# Update Rules with: hayabusa.exe --update-rules
-# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe -h
+# Update Rules with: hayabusa.exe update-rules
+# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe help

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_EventStatistics.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_EventStatistics.mkape
@@ -9,7 +9,6 @@ Processors:
     -
         Executable: hayabusa\hayabusa.exe
         CommandLine: metrics -d %sourceDirectory%  -o %destinationDirectory%\hayabusa_statistics.csv
-        ExportFormat: csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_EventStatistics.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_EventStatistics.mkape
@@ -9,6 +9,7 @@ Processors:
     -
         Executable: hayabusa\hayabusa.exe
         CommandLine: metrics -d %sourceDirectory%  -o %destinationDirectory%\hayabusa_statistics.csv
+        ExportFormat: csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_LiveResponse.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_LiveResponse.mkape
@@ -9,7 +9,6 @@ Processors:
     -
         Executable: hayabusa\hayabusa.exe
         CommandLine: csv-timeline --live-analysis -m med --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa.csv
-        ExportFormat: csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_LiveResponse.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_LiveResponse.mkape
@@ -9,6 +9,7 @@ Processors:
     -
         Executable: hayabusa\hayabusa.exe
         CommandLine: csv-timeline --live-analysis -m med --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa.csv
+        ExportFormat: csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_LiveResponse.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_LiveResponse.mkape
@@ -1,14 +1,14 @@
 Description: Hayabusa a timeline generator for Windows event logs - Live
 Category: EventLogs
-Author: Georg Lauenstein
-Version: 1.2
+Author: Georg Lauenstein (sure[secure])
+Version: 1.3
 Id: 9696412c-c973-4fd4-a426-06318011b8ba
 BinaryUrl: https://github.com/Yamato-Security/hayabusa/releases
 ExportFormat: csv
 Processors:
     -
         Executable: hayabusa\hayabusa.exe
-        CommandLine: --live-analysis -m med --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa.csv
+        CommandLine: csv-timeline --live-analysis -m med --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa.csv
         ExportFormat: csv
 
 # Documentation
@@ -16,6 +16,5 @@ Processors:
 # Place "zip archive" file into "Modules\bin\hayabusa" and unpack
 # rename the hayabusa executable to hayabusa.exe
 # You can delete all except: "config"; "rules" and the "hayabusa.exe"
-# Check version with: hayabusa.exe --version
-# Update Rules with: hayabusa.exe --update-rules
-# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe -h
+# Update Rules with: hayabusa.exe update-rules
+# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe help

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_LogonSummary.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_LogonSummary.mkape
@@ -1,22 +1,20 @@
 Description: Hayabusa a timeline generator for Windows event logs - Logon Summary
 Category: EventLogs
-Author: Georg Lauenstein
-Version: 1.1
+Author: Georg Lauenstein (sure[secure])
+Version: 1.2
 Id: 2dd36453-d175-4b54-b98f-9cdf492859ce
 BinaryUrl: https://github.com/Yamato-Security/hayabusa/releases
 ExportFormat: csv
 Processors:
     -
         Executable: hayabusa\hayabusa.exe
-        CommandLine: --live-analysis --RFC-3339 --quiet -U --logon-summary
+        CommandLine: logon-summary -l -o %destinationDirectory%\hayabusa_logon_summary.csv
         ExportFormat: csv
-        ExportFile: hayabusa_logon.csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder
 # Place "zip archive" file into "Modules\bin\hayabusa" and unpack
 # rename the hayabusa executable to hayabusa.exe
 # You can delete all except: "config"; "rules" and the "hayabusa.exe"
-# Check version with: hayabusa.exe --version
-# Update Rules with: hayabusa.exe --update-rules
-# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe -h
+# Update Rules with: hayabusa.exe update-rules
+# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe help

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_LogonSummary.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_LogonSummary.mkape
@@ -9,6 +9,7 @@ Processors:
     -
         Executable: hayabusa\hayabusa.exe
         CommandLine: logon-summary -l -o %destinationDirectory%\hayabusa_logon_summary.csv
+        ExportFormat: csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_LogonSummary.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_LogonSummary.mkape
@@ -9,7 +9,6 @@ Processors:
     -
         Executable: hayabusa\hayabusa.exe
         CommandLine: logon-summary -l -o %destinationDirectory%\hayabusa_logon_summary.csv
-        ExportFormat: csv
 
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
@@ -9,6 +9,7 @@ Processors:
     -
         Executable: hayabusa\hayabusa.exe
         CommandLine: csv-timeline -d %sourceDirectory% --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa_offline.csv
+        ExportFormat: csv
   
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
@@ -10,7 +10,7 @@ Processors:
         Executable: hayabusa\hayabusa.exe
         CommandLine: csv-timeline -d %sourceDirectory% --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa_offline.csv
         ExportFormat: csv
-  
+
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder
 # Place "zip archive" file into "Modules\bin\hayabusa" and unpack

--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
@@ -1,6 +1,6 @@
 Description: Hayabusa a timeline generator for Windows event logs - Offline
 Category: EventLogs
-Author: Georg Lauenstein
+Author: Georg Lauenstein (sure[secure])
 Version: 1.2
 Id: 49f9cd2d-3da5-4349-a9aa-c2b450582ccc
 BinaryUrl: https://github.com/Yamato-Security/hayabusa/releases
@@ -8,14 +8,12 @@ ExportFormat: csv
 Processors:
     -
         Executable: hayabusa\hayabusa.exe
-        CommandLine: -d %sourceDirectory% --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa.csv
-        ExportFormat: csv
-
+        CommandLine: csv-timeline -d %sourceDirectory% --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa_offline.csv
+  
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder
 # Place "zip archive" file into "Modules\bin\hayabusa" and unpack
 # rename the hayabusa executable to hayabusa.exe
 # You can delete all except: "config"; "rules" and the "hayabusa.exe"
-# Check version with: hayabusa.exe --version
-# Update Rules with: hayabusa.exe --update-rules
-# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe -h
+# Update Rules with: hayabusa.exe update-rules
+# Setup for RFC-3339 Time format. Check options for more: hayabusa.exe help

--- a/Modules/Compound/Hayabusa.mkape
+++ b/Modules/Compound/Hayabusa.mkape
@@ -1,9 +1,9 @@
 Description: Hayabusa a timeline generator for Windows event logs
 Category: EventLogs
-Author: Andrew Rathbun
-Version: 1.0
+Author: Andrew Rathbun, Georg Lauenstein (sure[secure])
+Version: 1.1
 Id: 0976ccf9-b7f8-4e5d-9bf7-96ba3b051db8
-BinaryUrl: https://f001.backblazeb2.com/file/EricZimmermanTools/MFTECmd.zip
+BinaryUrl: https://github.com/Yamato-Security/hayabusa/releases
 ExportFormat: csv
 Processors:
     -
@@ -22,8 +22,7 @@ Processors:
 # Documentation
 # Create a folder "hayabusa" within the "Modules\bin" KAPE folder
 # Place "zip archive" file into "Modules\bin\hayabusa" and unpack
-# rename hayabusa-1.4.3-win-x64.exe or hayabusa-1.4.3-win-x86.exe to hayabusa.exe
+# rename hayabusa-x.x.x.exe to hayabusa.exe
 # You can delete all except: "config"; "rules" and the "hayabusa.exe"
-# Check version with: hayabusa.exe --version
-# Update Rules with: hayabusa.exe --update-rules
+# Update Rules with: hayabusa.exe update-rules
 # Setup for European Time format. Check options for more: hayabusa.exe -h


### PR DESCRIPTION
## Description

```
Using Module operations
  Setting --msource to C:\temp\tout since --msource was not provided
  Flushing module destination directory C:\temp\mout
  Creating module destination directory C:\temp\mout
  Module hayabusa_EventStatistics: Found 1 processor
    Found processor Executable: hayabusa\hayabusa.exe, Cmd line: metrics -d %sourceDirectory%  -o %destinationDirectory%\hayabusa_statistics.csv, Export: csv, Append: False!
  Module hayabusa_LogonSummary: Found 1 processor
    Found processor Executable: hayabusa\hayabusa.exe, Cmd line: logon-summary -l -o %destinationDirectory%\hayabusa_logon_summary.csv, Export: csv, Append: False!
  Module hayabusa_OfflineEventLogs: Found 1 processor
    Found processor Executable: hayabusa\hayabusa.exe, Cmd line: csv-timeline -d %sourceDirectory% --RFC-3339 --quiet -U -o %destinationDirectory%\hayabusa_offline.csv, Export: csv, Append: False!
  Module hayabusa_UpdateRules: Found 1 processor
    Found processor Executable: hayabusa\hayabusa.exe, Cmd line: update-rules, Export: , Append: False!
Discovered 4 processors to run
Executing modules with file masks...
Executing remaining modules...
  Running hayabusa\hayabusa.exe: metrics -d C:\temp\tout  -o C:\temp\mout\EventLogs\hayabusa_statistics.csv
  Running hayabusa\hayabusa.exe: logon-summary -l -o C:\temp\mout\EventLogs\hayabusa_logon_summary.csv
  Running hayabusa\hayabusa.exe: csv-timeline -d C:\temp\tout --RFC-3339 --quiet -U -o C:\temp\mout\EventLogs\hayabusa_offline.csv
  Running hayabusa\hayabusa.exe: update-rules
Executed 4 processors in 35.1940 seconds
```

Thank you for your submission and for contributing to the DFIR community!
