### PR TITLE
Update USBDevicesLogs.tkape

### DIFF
--- a/Targets/Windows/USBDevicesLogs.tkape
+++ b/Targets/Windows/USBDevicesLogs.tkape
@@ -1,7 +1,7 @@
 Description: USB devices log files
-Author: Eric Zimmerman
-Version: 1.0
-Id: 07ee308f-c79a-47de-a431-c93ab34e4b66
+Author: Eric Zimmerman, esecrpm
+Version: 1.1
+Id: 1c1d3c54-fb49-4ed1-81f7-03c6744167a1
 RecreateDirectories: true
 Targets:
     -
@@ -13,15 +13,19 @@ Targets:
         Name: Setupapi.log Win7+
         Category: USBDevices
         Path: C:\Windows\inf\
-        FileMask: setupapi.dev.log
+        FileMask: setupapi.*.log
     -
         Name: Setupapi.log Win7+
         Category: USBDevices
         Path: C:\Windows.old\Windows\inf\
-        FileMask: setupapi.dev.log
+        FileMask: setupapi.*.log
 
 # Documentation
 # https://www.andreafortuna.org/2018/02/09/usb-devices-in-windows-forensic-analysis/
 # https://www.hecfblog.com/2013/08/daily-blog-66-understanding-artifacts.html
 # https://www.swiftforensics.com/2012/08/tracking-usb-first-insertion-in-event.html
 # https://www.13cubed.com/downloads/dfir_cheat_sheet.pdf
+#
+# v1.1
+# Use wildcard to account for dated versions files and other forms of setupapi log
+# Ex: setupapi.dev.20221214_093731.log, setupapi.setup.log, setupapi.upgrade.log


### PR DESCRIPTION
Update to account for dated versions of files and other forms of setupapi log files.

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [ ] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
