### PR TITLE
Additional logs from SANS Hunt Evil poster

### DIFF
--- a/Targets/Windows/EventLogs-RDP.tkape
+++ b/Targets/Windows/EventLogs-RDP.tkape
@@ -1,7 +1,7 @@
 Description: Collect Win7+ RDP related Event logs
-Author: Mark Hallman
-Version: 1.0
-Id: 2e79fc64-816c-439a-8b7f-93dd59bf2711
+Author: Mark Hallman, esecrpm
+Version: 1.1
+Id: 9a63391e-87fd-4db1-a646-41f852b940a1
 RecreateDirectories: true
 Targets:
     -
@@ -27,13 +27,43 @@ Targets:
     -
         Name: Event logs Win7+
         Category: EventLogs
-        Path: C:\Windows\System32\winevt\Logs\Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx
-        FileMask: Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx
+        Path: C:\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-TerminalServices-RDPClient%4Operational.evtx
+    -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-TerminalServices-RDPClient%4Operational.evtx
     -
         Name: Event logs Win7+
         Category: EventLogs
         Path: C:\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-RemoteDesktopServices-RdpCoreTS%4Operational.evtx
+     -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-RemoteDesktopServices-RdpCoreTS%4Operational.evtx
+   -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows\System32\winevt\Logs\
         FileMask: Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational.evtx
+    -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational.evtx
+   -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx
+   -
+        Name: Event logs Win7+
+        Category: EventLogs
+        Path: C:\Windows.old\Windows\System32\winevt\Logs\
+        FileMask: Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx
 
 # Documentation
 # https://medium.com/@lucideus/introduction-to-event-log-analysis-part-1-windows-forensics-manual-2018-b936a1a35d8a
@@ -41,3 +71,18 @@ Targets:
 # https://www.digitalforensics.com/blog/forensic-analysis-of-windows-event-logs-windows-files-activities-audit/
 # https://youtu.be/Xw536W7kbDQ
 # https://www.youtube.com/watch?v=myzG11BP3Sk
+# https://www.sans.org/posters/?focus-area=digital-forensics
+# https://www.sans.org/posters/hunt-evil/
+#
+# v1.1
+# Including additional event logs for RDP events specified on SANS Hunt Evil ("Blue") poster
+#
+# Source
+# Security.evtx
+# Microsoft-Windows-TerminalServices-RDPClient%4Operational.evtx
+#
+# Destination
+# Security.evtx
+# Microsoft-Windows-RemoteDesktopServices-RdpCoreTS%4Operational.evtx
+# Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational.evtx
+# Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx

--- a/Targets/Windows/EventLogs-RDP.tkape
+++ b/Targets/Windows/EventLogs-RDP.tkape
@@ -39,12 +39,12 @@ Targets:
         Category: EventLogs
         Path: C:\Windows\System32\winevt\Logs\
         FileMask: Microsoft-Windows-RemoteDesktopServices-RdpCoreTS%4Operational.evtx
-     -
+    -
         Name: Event logs Win7+
         Category: EventLogs
         Path: C:\Windows.old\Windows\System32\winevt\Logs\
         FileMask: Microsoft-Windows-RemoteDesktopServices-RdpCoreTS%4Operational.evtx
-   -
+    -
         Name: Event logs Win7+
         Category: EventLogs
         Path: C:\Windows\System32\winevt\Logs\
@@ -54,12 +54,12 @@ Targets:
         Category: EventLogs
         Path: C:\Windows.old\Windows\System32\winevt\Logs\
         FileMask: Microsoft-Windows-TerminalServices-RemoteConnectionManager%4Operational.evtx
-   -
+    -
         Name: Event logs Win7+
         Category: EventLogs
         Path: C:\Windows\System32\winevt\Logs\
         FileMask: Microsoft-Windows-TerminalServices-LocalSessionManager%4Operational.evtx
-   -
+    -
         Name: Event logs Win7+
         Category: EventLogs
         Path: C:\Windows.old\Windows\System32\winevt\Logs\


### PR DESCRIPTION
## Description

Added Microsoft-Windows-TerminalServices-RDPClient%4Operational.evtx and Microsoft-Windows-RemoteDesktopServices-RdpCoreTS%4Operational.evtx logs from SANS blue poster.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [ ] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
