### PR TITLE
Fix Error in Running BitsParser

### DIFF
--- a/Modules/Apps/GitHub/BitsParser.mkape
+++ b/Modules/Apps/GitHub/BitsParser.mkape
@@ -8,7 +8,7 @@ ExportFormat: json
 Processors:
     -
         Executable: BitsParser.exe
-        CommandLine: -i %sourceDirectory%\C\ProgramData\Microsoft\Network\Downloader\qmgr.db -o %destinationDirectory%\BitsParser_Results.json
+        CommandLine: -i %sourceDirectory%C\ProgramData\Microsoft\Network\Downloader\qmgr.db -o %destinationDirectory%\BitsParser_Results.json
         ExportFormat: json
 
 # Documentation


### PR DESCRIPTION
SourceDirectory adds a backslash.  When fully expanded, it presents bitsparser with a double backslash which causes an error.

## Description

Removed backslash after %sourcedirectory%.  Expanded it sends a double backslash to bitsparser which errors out.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X ] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X ] I have set or updated the version of my Target(s)/Module(s)
- [X ] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X ] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [X ] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
