### PR TITLE
Add PowerShell_Execute-Winlogbeat module

### DIFF
--- a/Modules/Apps/GitHub/PowerShell_Execute-Winlogbeat.mkape
+++ b/Modules/Apps/GitHub/PowerShell_Execute-Winlogbeat.mkape
@@ -1,0 +1,18 @@
+Description: Execute-Winlogbeat.ps1 - Recursively process the source directory to execute Winlogbeat once on all EVTX files found.
+Category: EventLogs
+Author: Thomas DIOT (Qazeer)
+Version: 1.0
+Id: e4ff9d06-2548-43b4-b037-7d7f1d37cfea
+BinaryUrl: https://gist.github.com/Qazeer/4936ec6c9fa511500f9496d0ceacab22
+ExportFormat: JSON
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: "& '%kapeDirectory%\\Modules\\bin\\Execute-Winlogbeat.ps1' -WinlogbeatBinary '%kapeDirectory%\\Modules\\bin\\Winlogbeat\\winlogbeat.exe' -InputDir '%sourceDirectory%' -OutputDir '%destinationDirectory%'"
+        ExportFormat: JSON
+
+# Documentation
+# Recursively process the source directory to execute Winlogbeat once on all EVTX files found.
+# Execute-Winlogbeat.ps1 is basically a wrapper to make Winlogbeat recursive, with out a predefined set of EVTX files to look for.
+# https://gist.github.com/Qazeer/4936ec6c9fa511500f9496d0ceacab22
+# Winlogbeat (https://www.elastic.co/fr/downloads/beats/winlogbeat) full folder must be placed under "%kapeDirectory%\Modules\bin\Winlogbeat".


### PR DESCRIPTION
## Description

Add PowerShell_Execute-Winlogbeat module, to recursively process the source directory to execute Winlogbeat once on all EVTX files found.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
