### PR TITLE
Add PowerShell_Execute-BmcTools module

### DIFF
--- a/Modules/Apps/GitHub/PowerShell_Execute-BmcTools.mkape
+++ b/Modules/Apps/GitHub/PowerShell_Execute-BmcTools.mkape
@@ -1,0 +1,18 @@
+Description: Execute-BmcTools.ps1 - Recursively process the specified input folder to execute bmc-tools.exe over each Bitmap Cache subfolder(s) found.
+Category: RemoteAccess
+Author: Thomas DIOT (Qazeer)
+Version: 1.0
+Id: 5ac4cc42-cbf4-4862-9d4a-083ea5a16a28
+BinaryUrl: https://gist.github.com/Qazeer/3a6d43a117bbece6d83e7e79687e0870
+ExportFormat: bmp
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: "& '%kapeDirectory%\\Modules\\bin\\Execute-BmcTools.ps1' -bmcToolsBinary '%kapeDirectory%\\Modules\\bin\\bmc-tools.exe' -InputDir '%sourceDirectory%' -OutputDir '%destinationDirectory%'"
+        ExportFormat: bmp
+
+# Documentation
+# Recursively process the specified input folder to execute bmc-tools.exe over each Bitmap Cache subfolder(s) found.
+# bmc-tools is a Python RDP Bitmap Cache parser from ANSSI (https://github.com/ANSSI-FR/bmc-tools).
+# bmc-tools.exe (https://github.com/Qazeer/bmc-tools-compiled/releases/download/v3.02/bmc-tools.exe) is a compiled version of the bmc-tools.py that must be placed under "%kapeDirectory%\Modules\bin\bmc-tools.exe".
+# Execute-BmcTools.ps1 (https://gist.github.com/Qazeer/3a6d43a117bbece6d83e7e79687e0870) is basically a wrapper to make bmc-tools.exe output results to user specific folders.


### PR DESCRIPTION
## Description

Add the PowerShell_Execute-BmcTools module, to improve the current BMC-Tools_RDPBitmapCacheParser module (that references a non functionning compiled bmc-tools.exe and outputs all results to the same directory). This module uses an up-to-date version of bmc-tools.exe and a PowerShell script wrapper to output results in user specific folders.

## Checklist:

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format