### PR TITLE
NETCLRUsageLogs-update

### DIFF
--- a/Targets/Compound/CombinedLogs.tkape
+++ b/Targets/Compound/CombinedLogs.tkape
@@ -1,6 +1,6 @@
-Description: Collect Event logs, Trace logs, Windows Firewall and PowerShell console
-Author: Mike Cary, Mark Hallman added the USBDevicelogs target
-Version: 1.1
+Description: Collect Event logs, Trace logs, Windows Firewall, PowerShell console logs, and .NET CLR UsageLogs
+Author: Mike Cary, Mark Hallman added the USBDevicelogs target, Thomas DIOT (Qazeer) added the .NET CLR UsageLogs target
+Version: 1.2
 Id: d4fdd600-15b1-4b78-bc77-88e724861d8d
 RecreateDirectories: true
 Targets:
@@ -24,6 +24,11 @@ Targets:
         Name: USBDevicesLogs
         Category: USB
         Path: USBDevicesLogs.tkape
+    -
+        Name: .NET CLR UsageLogs
+        Category: .NET CLR UsageLogs
+        Path: NETCLRUsageLogs.tkape
 
 # Documentation
 # v1.1 - Added the USBDevicelogs target
+# v1.2 - Added the .NET CLR UsageLogs target

--- a/Targets/Windows/NETCLRUsageLogs.tkape
+++ b/Targets/Windows/NETCLRUsageLogs.tkape
@@ -1,14 +1,21 @@
 Description: .NET CLR UsageLogs
-Author: Matias Davaro
-Version: 1.0
+Author: Matias Davaro, Thomas DIOT (Qazeer)
+Version: 1.1
 Id: f127a2a3-d86f-4ede-96e7-52193db822ad
 RecreateDirectories: true
 Targets:
     -
-        Name: .NET CLR UsageLogs
+        Name: .NET CLR UsageLogs (user-scoped)
         Category: .NET CLR UsageLogs
-        Path: C:\Users\%user%\AppData\Local\Microsoft\CLR_*\UsageLogs
+        Path: C:\Users\%user%\AppData\Local\Microsoft\CLR_*\
         Recursive: true
+        FileMask: '*.log'
+    -
+        Name: .NET CLR UsageLogs (system-scoped)
+        Category: .NET CLR UsageLogs
+        Path: C:\Windows*\System32\config\systemprofile\AppData\Local\Microsoft\CLR_*\
+        Recursive: true
+        FileMask: '*.log'
 
 # Documentation
 # https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
