### PR TITLE
Add the no wizard flag for new hayabusa version

### DIFF
--- a/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
+++ b/Modules/Apps/GitHub/Hayabusa/hayabusa_OfflineEventLogs.mkape
@@ -1,14 +1,14 @@
 Description: Hayabusa a timeline generator for Windows event logs - Offline
 Category: EventLogs
 Author: Georg Lauenstein (sure[secure])
-Version: 1.3
+Version: 1.4
 Id: 49f9cd2d-3da5-4349-a9aa-c2b450582ccc
 BinaryUrl: https://github.com/Yamato-Security/hayabusa/releases
 ExportFormat: csv
 Processors:
     -
         Executable: hayabusa\hayabusa.exe
-        CommandLine: csv-timeline -d %sourceDirectory% --profile standard --quiet --UTC -o %destinationDirectory%\hayabusa_events_offline.csv
+        CommandLine: csv-timeline -d %sourceDirectory% --profile standard -w --quiet --UTC -o %destinationDirectory%\hayabusa_events_offline.csv
         ExportFormat: csv
 
 # Documentation


### PR DESCRIPTION
## Description

Add the `-w` option to run `Hayabusa`, as otherwise an interactive wizard is displayed since version [v2.10.0](https://github.com/Yamato-Security/hayabusa/releases/tag/v2.10.0) (resulting in an error if executed through `KAPE`).


## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
