### PR TITLE
Update PowerShell Transcripts default location

### DIFF
--- a/Targets/Windows/PowerShellTranscripts.tkape
+++ b/Targets/Windows/PowerShellTranscripts.tkape
@@ -1,11 +1,16 @@
 Description: PowerShell Transcripts
 Author: Andrew Rathbun and Chad Tilbury
-Version: 1.0
+Version: 1.1
 Id: 316cd490-7a40-4518-aade-1de070191f3d
 RecreateDirectories: true
 Targets:
     -
         Name: PowerShell Transcripts - Default Location
+        Category: PowerShellTranscripts
+        Path: C:\Users\%user%\Documents\
+        FileMask: 'PowerShell_transcript.*.txt'
+    -
+        Name: PowerShell Transcripts - Observed Location
         Category: PowerShellTranscripts
         Path: C:\Users\%user%\Documents\20*\
         FileMask: 'PowerShell_transcript.*.txt'
@@ -26,9 +31,11 @@ Targets:
         FileMask: 'PowerShell_transcript.*.txt'
 
 # Documentation
+# https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.host/start-transcript
 # https://lazyadmin.nl/powershell/start-transcript/
 # https://www.stigviewer.com/stig/windows_10/2021-03-10/finding/V-230220
 # https://www.itprotoday.com/powershell/how-use-automatic-powershell-transcription
+# https://artefacts.help/windows_powershell_transcript.html
 # These logs appears when auditing is turned on via Group Policy or Start-Transcript is used during PowerShell execution
 # As more locations are observed, they will be added here
-# Example location (default): c:\users\name\documents\20220301\PowerShell_transcript.DEVICENAME.qp9EOTN2.20220301132612.txt
+# Example location: C:\Users\USERNAME\Documents\20220301\PowerShell_transcript.DEVICENAME.qp9EOTN2.20220301132612.txt


### PR DESCRIPTION
## Description

Update the default location of `PowerShell transcripts` to `C:\Users\%user%\Documents\` (from `C:\Users\%user%\Documents\20*\`).

According to [MS documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.host/start-transcript) and personnal tests, the transcripts files are directly placed into a user documents folder by default. Tested on `PowerShell 2.0` (on `Windows XP`), `PowerShell 4.0` (on `Windows Server 2012R2`), `PowerShell 5.1` and `PowerShell 7.2` (on `Windows 10`).

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
