### PR TITLE
Add PowerShell Transcripts to combined logs

### DIFF
--- a/Targets/Compound/CombinedLogs.tkape
+++ b/Targets/Compound/CombinedLogs.tkape
@@ -1,6 +1,6 @@
 Description: Collect Event logs, Trace logs, Windows Firewall, PowerShell console logs, and .NET CLR UsageLogs
-Author: Mike Cary, Mark Hallman added the USBDevicelogs target, Thomas DIOT (Qazeer) added the .NET CLR UsageLogs target
-Version: 1.2
+Author: Mike Cary, Mark Hallman added the USBDevicelogs target, Thomas DIOT (Qazeer) added the .NET CLR UsageLogs and PowerShell Transcripts target
+Version: 1.3
 Id: d4fdd600-15b1-4b78-bc77-88e724861d8d
 RecreateDirectories: true
 Targets:
@@ -17,6 +17,10 @@ Targets:
         Category: PowerShellConsoleLog
         Path: PowerShellConsole.tkape
     -
+        Name: PowerShell Transcripts
+        Category: PowerShellTranscripts
+        Path: PowerShellTranscripts.tkape
+    -
         Name: Windows Firewall Log
         Category: WindowsFirewallLogs
         Path: WindowsFirewall.tkape
@@ -32,3 +36,4 @@ Targets:
 # Documentation
 # v1.1 - Added the USBDevicelogs target
 # v1.2 - Added the .NET CLR UsageLogs target
+# v1.3 - Added the PowerShell Transcripts target


### PR DESCRIPTION
## Description

Add `PowerShellTranscripts` target to the `CombinedLogs` compound target.

## Checklist:

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
