### PR TITLE
Fixes Block Parser to be path independent

### DIFF
--- a/Modules/Apps/block-parser-zipped.mkape
+++ b/Modules/Apps/block-parser-zipped.mkape
@@ -1,14 +1,15 @@
 Description: Block Parser Zipped
 Category: EventLogs
-Author: Phill Moore
-Version: 1.0
+Author: Phill Moore, Reece394
+Version: 1.1
 Id: cb817a29-bab0-4051-ac7d-7019d6e2ac65
 BinaryUrl: https://github.com/randomaccess3/block-parser
+FileMask: "Microsoft-Windows-PowerShell%4Operational.evtx"
 ExportFormat: zip
 Processors:
     -
         Executable: block-parser.exe
-        CommandLine: -o %destinationDirectory% -z "%sourceDirectory%\Windows\system32\winevt\logs\Microsoft-Windows-PowerShell%4Operational.evtx
+        CommandLine: -o %destinationDirectory% -z %sourceFile%
         ExportFormat: zip
 
 # Documentation


### PR DESCRIPTION
## Description

Block Parser Zipped had a hardcoded path which meant if the log path was different it would not work. 

This fix looks for the Microsoft-Windows-PowerShell%4Operational.evtx file anywhere it could exist making it likelier to work for a higher number of people.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
