### PR TITLE
Update WindowsTimeline target to be recursive on ConnectedDevicesPlat…

### DIFF
--- a/Targets/Windows/WindowsTimeline.tkape
+++ b/Targets/Windows/WindowsTimeline.tkape
@@ -1,13 +1,14 @@
 Description: ActivitiesCache.db collector
-Author: Lee Whitfield
-Version: 1.0
+Author: Lee Whitfield, Thomas DIOT (Qazeer)
+Version: 1.1
 Id: 8315040f-c9a4-455a-b02c-96372583f436
 RecreateDirectories: true
 Targets:
     -
         Name: ActivitiesCache.db
         Category: FileFolderAccess
-        Path: C:\Users\%user%\AppData\Local\ConnectedDevicesPlatform\*\
+        Path: C:\Users\%user%\AppData\Local\ConnectedDevicesPlatform\
+        Recursive: true
         FileMask: ActivitiesCache.db*
 
 # Documentation


### PR DESCRIPTION
Update the `WindowsTimeline` target to recursively search the `ActivitiesCache.db`  file under the `ConnectedDevicesPlatform` folder instead of looking for it in a subfolder. The `ActivitiesCache.db` file may be stored directly under the `ConnectedDevicesPlatform` folder (was the case for Windows Server 2016, build `14393.rs1_release.240801-2004`).

## Checklist:

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format