### PR TITLE
Add PowerShell_Execute-UsnJrnlRewind module

### DIFF
--- a/Modules/Apps/GitHub/PowerShell_Execute-UsnJrnlRewind.mkape
+++ b/Modules/Apps/GitHub/PowerShell_Execute-UsnJrnlRewind.mkape
@@ -1,0 +1,20 @@
+Description: Execute-UsnJrnlRewind.ps1 - Execute usnjrnl_rewind.exe on MFT and UsnJrnl CSV from MFTEcmd to "rewind" the UsnJrnl and add their full path to UsnJrnl entries. Works on the module destination directory.
+Category: FileSystem
+Author: CyberCX-DFIR, Thomas DIOT (Qazeer)
+Version: 1.0
+Id: 82db8f91-7131-4c8e-a2d6-48cb52336ff9
+BinaryUrl: https://gist.github.com/Qazeer/2b90b93dfc21e0987e73302703e4b9e0
+ExportFormat: CSV
+Processors:
+    -
+        Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        CommandLine: "& '%kapeDirectory%\\Modules\\bin\\Execute-UsnJrnlRewind.ps1' -UsnJrnlRewindBinary '%kapeDirectory%\\Modules\\bin\\usnjrnl_rewind.exe' -InputDir '%destinationDirectory%' -OutputDir '%destinationDirectory%'"
+        ExportFormat: CSV
+
+# Documentation
+# Process the module destinationDirectory\Filesystem folder to rewind the UsnJrnl following an execution of the MFTEcmd_$MFT and MFTEcmd_$J KAPE modules.
+# Execute-UsnJrnlRewind.ps1 is a simple wrapper to usnjrnl_rewind.exe that finds and executes usnjrnl_rewind.exe on MFT and UsnJrnl CSV found in the specified folder.
+# CyberCX NTFS Usnjrnl Rewind: https://cybercx.com.au/blog/ntfs-usnjrnl-rewind/
+# Original usnjrnl_rewind.py: https://github.com/CyberCX-DFIR/usnjrnl_rewind
+# Execute-UsnJrnlRewind.ps1 wrapper: https://gist.github.com/Qazeer/2b90b93dfc21e0987e73302703e4b9e0
+# usnjrnl_rewind.exe (https://github.com/Qazeer/usnjrnl_rewind_compiled/releases) must be placed under "%kapeDirectory%\Modules\bin\usnjrnl_rewind.exe".


### PR DESCRIPTION
## Description

Add the `PowerShell_Execute-UsnJrnlRewind` module, that executes CyberCX-DFIR's [`usnjrnl_rewind`](https://github.com/CyberCX-DFIR/usnjrnl_rewind) Python script (through the PowerShell wrapper [`Execute-UsnJrnlRewind.ps1`](https://gist.github.com/Qazeer/2b90b93dfc21e0987e73302703e4b9e0) and using a [compiled version](https://github.com/Qazeer/usnjrnl_rewind_compiled)).

`usnjrnl_rewind` uses parsed `MFT` and `UsnJrnl` CSV from `MFTEcmd` to "rewind" the `UsnJrnl` and add their full path to `UsnJrnl` entries.

Note: `usnjrnl_rewind` appears to have a little bug on numerical filenames, a [PR has been submitted](https://github.com/CyberCX-DFIR/usnjrnl_rewind/pull/2).

## Checklist:

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format