### PR TITLE
Fixing duplicate Module ID on two compound

### DIFF
--- a/Modules/Compound/Persistence.mkape
+++ b/Modules/Compound/Persistence.mkape
@@ -2,7 +2,7 @@ Description: Parsing all Persistence category
 Category: Persistence
 Author: Max Zabuty
 Version: 1
-Id: 8da4a739-5367-47ca-ab84-12f4a0f8e0de
+Id: 65f33b7e-aba8-4e1e-85f1-8c40e1f23083
 ExportFormat: json
 Processors:
     -


### PR DESCRIPTION
Hey, fixing duplicate modules ID (Persistence.mkape and NetworkActivity.mkape)

## Description

These 2 modules had the same ID, generating an error while running : 
![image](https://github.com/user-attachments/assets/e5e36a94-d83e-4be5-9087-a1bc8d2ac459)


## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)


