### PR TITLE
Windows 11 Notepad (TabState) and CertUtil parsers.

### DIFF
--- a/Modules/Apps/GitHub/CertUtil_Parser.mkape
+++ b/Modules/Apps/GitHub/CertUtil_Parser.mkape
@@ -6,8 +6,8 @@ Id: 7d18d1ad-13b5-435c-a5f1-063093e39646
 BinaryUrl: https://github.com/AbdulRhmanAlfaifi/CryptnetURLCacheParser/releases/tag/1.1/CryptnetUrlCacheParser.exe
 ExportFormat: csv
 Processors:
-  - Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-    CommandLine: "& \"%kapeDirectory%\\Modules\\bin\\CryptnetUrlCacheParser.exe\" -o \"%destinationDirectory%\\Certutil_Parsed.csv\""
+  - Executable: CryptnetUrlCacheParser.exe
+    CommandLine: "-o \"%destinationDirectory%\\Certutil_Parsed.csv\""
     ExportFormat: csv
 
 # Documentation

--- a/Modules/Apps/GitHub/CertUtil_Parser.mkape
+++ b/Modules/Apps/GitHub/CertUtil_Parser.mkape
@@ -1,0 +1,18 @@
+Description: A Module to parse Certutil activity
+Category: Windows
+Author: DReneau
+Version: 1.0
+Id: 7d18d1ad-13b5-435c-a5f1-063093e39646
+BinaryUrl: https://github.com/AbdulRhmanAlfaifi/CryptnetURLCacheParser/releases/tag/1.1/CryptnetUrlCacheParser.exe
+ExportFormat: csv
+Processors:
+  - Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+    CommandLine: "& \"%kapeDirectory%\\Modules\\bin\\CryptnetUrlCacheParser.exe\" -o \"%destinationDirectory%\\Certutil_Parsed.csv\""
+    ExportFormat: csv
+
+# Documentation
+# https://u0041.co/posts/articals/certutil-artifacts-analysis/
+# https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil
+# https://thinkdfir.com/2020/07/30/certutil-download-artefacts/
+# Certutil is a Windows utility used by threat actors to download arbitrary files/tools using Land Binary (LOLBin)  techniques.
+# Certutil can also be used to base64 encode/decode and calculate file hashes.

--- a/Modules/Apps/GitHub/Notepad_Parser.mkape
+++ b/Modules/Apps/GitHub/Notepad_Parser.mkape
@@ -1,0 +1,18 @@
+Description: A Module to parse (Windows 11+) Notepad TabState files.
+Category: Windows
+Author: DReneau
+Version: 1.0
+Id: b5a8a229-4897-4bda-a8f0-f2246362664f
+BinaryUrl: https://github.com/AbdulRhmanAlfaifi/notepad_parser/releases/download/v0.1.0/notepad_parser.exe
+ExportFormat: json
+Processors:
+  - Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+    CommandLine: "Get-ChildItem -Recurse '%sourceDirectory%' -Filter '*.bin' | Where-Object { $_.FullName -like '*Microsoft.WindowsNotepad_8wekyb3d8bbwe\\LocalState\\TabState*' } | ForEach-Object { $outputFile = Join-Path '%destinationDirectory%' ([System.IO.Path]::GetFileNameWithoutExtension($_.FullName) + '.json'); $tempFile = Join-Path '%destinationDirectory%' ([System.IO.Path]::GetFileNameWithoutExtension($_.FullName) + '_temp.json'); & '%kapeDirectory%\\Modules\\bin\\notepad_parser.exe' \"$($_.FullName)\" -f jsonl -o $tempFile; if (Test-Path $outputFile) { Remove-Item $outputFile }; Rename-Item $tempFile $outputFile }"
+    ExportFormat: json
+
+# Documentation
+# https://u0041.co/posts/articals/exploring-windows-artifacts-notepad-files/
+# Windows 11 Notepad stores a cache of recently opened files. This cache contains valuable information, such as file paths, file contents, and other useful data.
+# This parser written by AbdulRhman Alfaifi will parse the Windows 11 Notepad cache, specifically the TabState.
+# The Notepad artifacts are stored here: "%LOCALAPPDATA%\Packages\Microsoft.WindowsNotepad _8wekyb3d8bbwe\LocalState"
+


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [x] I have generated a unique `GUID` for my Target(s)/Module(s)
- [x] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [x] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [x] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [x] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
