### PR TITLE
Add MongoDB log collection target for CVE-2025-14847

### DIFF
--- a/Targets/Compound/ServerTriage.tkape
+++ b/Targets/Compound/ServerTriage.tkape
@@ -1,6 +1,6 @@
 Description: A compound target for gathering artifacts common to servers.
 Author: Eric Capuano
-Version: 1.0
+Version: 1.1
 Id: 9bea625c-00bd-4389-a0a5-f648e8e267ce
 RecreateDirectories: true
 Targets:
@@ -8,6 +8,10 @@ Targets:
         Name: WebServers
         Category: Compound
         Path: WebServers.tkape
+    -
+        Name: MongoDB Logs
+        Category: Logs
+        Path: MongoDBLogs.tkape
     -
         Name: Exchange
         Category: Compound
@@ -30,4 +34,5 @@ Targets:
         Path: ManageEngineLogs.tkape
 
 # Documentation
+# v1.1 - Added MongoDB Logs target
 # A Target to run on generic servers when their role is unknown. Includes common server applications.

--- a/Targets/Logs/MongoDBLogs.tkape
+++ b/Targets/Logs/MongoDBLogs.tkape
@@ -1,0 +1,44 @@
+Description: MongoDB Log Files (Windows)
+Author: Eric Capuano
+Version: 1.0
+Id: 2e5c341b-d10a-466d-a40e-abb478212e00
+RecreateDirectories: true
+Targets:
+    -
+        Name: MongoDB Logs (Program Files)
+        Category: Logs
+        Path: C:\Program Files\MongoDB\Server\*\log\
+        Recursive: true
+        FileMask: "*.log*"
+        Comment: "MongoDB log files in default MSI install log directory"
+    -
+        Name: MongoDB Logs (Program Files - logs folder)
+        Category: Logs
+        Path: C:\Program Files\MongoDB\Server\*\logs\
+        Recursive: true
+        FileMask: "*.log*"
+        Comment: "MongoDB log files when folder is named 'logs'"
+    -
+        Name: MongoDB Logs (C:\data\log)
+        Category: Logs
+        Path: C:\data\log\
+        Recursive: true
+        FileMask: "*.log*"
+        Comment: "Common default MongoDB log directory for manual installations"
+    -
+        Name: MongoDB Logs (ProgramData)
+        Category: Logs
+        Path: C:\ProgramData\MongoDB\log\
+        Recursive: true
+        FileMask: "*.log*"
+        Comment: "Log directory for MongoDB Windows service installations"
+    -
+        Name: MongoDB Logs (Alternate Install)
+        Category: Logs
+        Path: C:\MongoDB\log\
+        Recursive: true
+        FileMask: "*.log*"
+        Comment: "Common non-default install log directory"
+
+# Documentation
+# https://www.mongodb.com/docs/manual/reference/log-messages/


### PR DESCRIPTION
## Summary

Adds MongoDB log collection capabilities to support incident response for **CVE-2025-14847** (MongoBleed), a critical memory leak vulnerability in MongoDB's zlib message decompression.

### Changes
- **New target**: `Targets/Logs/MongoDBLogs.tkape` - Collects MongoDB log files from common Windows installation paths
- **Updated**: `Targets/Compound/ServerTriage.tkape` (v1.1) - Now includes MongoDB logs

### Log Paths Covered
- `C:\Program Files\MongoDB\Server\*\log\` and `\logs\`
- `C:\data\log\`
- `C:\ProgramData\MongoDB\log\`
- `C:\MongoDB\log\`

### Why This Matters

MongoBleed exploitation generates distinctive log patterns that are critical for detection:
- Rapid connection bursts (thousands of connections in seconds)
- Connection accepted/ended pairs with <10ms duration
- Connections without compression negotiation

These logs enable behavioral detection of exploitation attempts against vulnerable MongoDB instances (versions 4.4.0-4.4.29, 5.0.0-5.0.31, 6.0.0-6.0.26, 7.0.0-7.0.27, 8.0.0-8.0.16, 8.2.0-8.2.2).

## References
- [Hunting MongoBleed (CVE-2025-14847)](https://blog.ecapuano.com/p/hunting-mongobleed-cve-2025-14847)
- [MongoDB Security Incident - DoublePulsar](https://doublepulsar.com/merry-christmas-day-have-a-mongodb-security-incident-9537f54289eb)
- [CVE-2025-14847 Technical Analysis - OX Security](https://www.ox.security/blog/attackers-could-exploit-zlib-to-exfiltrate-data-cve-2025-14847/#technical_analysis)

## Note
These artifacts were developed on macOS without the ability to validate with KAPE locally. YAML syntax and structure have been validated programmatically and cross-referenced against existing targets in the repository.