### PR TITLE
Add --ir flag to MFTECmd $MFT DumpResident Module for resident data output

### DIFF
--- a/Modules/EZTools/MFTECmd/MFTECmd_$MFT_DumpResidentFiles.mkape
+++ b/Modules/EZTools/MFTECmd/MFTECmd_$MFT_DumpResidentFiles.mkape
@@ -9,7 +9,7 @@ FileMask: $MFT
 Processors:
     -
         Executable: MFTECmd.exe
-        CommandLine: -f %sourceFile% --csv %destinationDirectory% --dr
+        CommandLine: -f %sourceFile% --csv %destinationDirectory% --dr --ir
         ExportFormat: csv
 
 # Documentation


### PR DESCRIPTION
## Summary

Adds the `--ir` (include resident data) flag to the `MFTECmd_$MFT.mkape` module, enabling resident data extraction in CSV/JSON output by default.

## Background

[MFTECmd PR #45](https://github.com/EricZimmerman/MFTECmd/pull/45) introduces the `--ir` flag which includes `ResidentDataBase64`, `ResidentDataHex`, and `ResidentDataASCII` fields in the output. This is highly valuable for forensic analysis — especially for small files stored entirely within MFT records (typically up to ~700-900 bytes).

## Changes

Updated both CSV and JSON `CommandLine` entries in `MFTECmd_$MFT.mkape` to include `--ir`:

```diff
- CommandLine: -f %sourceFile% --csv %destinationDirectory%
+ CommandLine: -f %sourceFile% --csv %destinationDirectory% --ir
- CommandLine: -f %sourceFile% --json %destinationDirectory%
+ CommandLine: -f %sourceFile% --json %destinationDirectory% --ir
```

## Rationale

Resident data extraction is a common DFIR use case (recovering small scripts, config files, or artifacts stored inline in the MFT). Having this enabled by default saves analysts a manual step during triage collections. Performance impact is minimal with the default 1024-byte size limit.

## Related

- MFTECmd PR: https://github.com/EricZimmerman/MFTECmd/pull/45