### PR TITLE
Add TruffleHog module for detecting secrets in collected artifacts

### DIFF
--- a/Modules/Apps/GitHub/TruffleHog_Secrets.mkape
+++ b/Modules/Apps/GitHub/TruffleHog_Secrets.mkape
@@ -6,10 +6,10 @@ Id: 41f5c5e8-7a5b-4b3e-9c3d-2d8f3a9d4b72
 BinaryUrl: https://github.com/trufflesecurity/trufflehog/releases/latest
 ExportFormat: json
 
-# Documentation
-# N/A
-
 Processors:
   -
     Executable: TruffleHog\trufflehog.exe
     CommandLine: filesystem "%sourceDirectory%" --json > "%destinationDirectory%\trufflehog_results.json"
+
+# Documentation
+# N/A

--- a/Modules/Apps/GitHub/TruffleHog_Secrets.mkape
+++ b/Modules/Apps/GitHub/TruffleHog_Secrets.mkape
@@ -6,6 +6,9 @@ Id: 41f5c5e8-7a5b-4b3e-9c3d-2d8f3a9d4b72
 BinaryUrl: https://github.com/trufflesecurity/trufflehog/releases/latest
 ExportFormat: json
 
+# Documentation
+# N/A
+
 Processors:
   -
     Executable: TruffleHog\trufflehog.exe

--- a/Modules/Apps/TruffleHog_Secrets.mkape
+++ b/Modules/Apps/TruffleHog_Secrets.mkape
@@ -1,0 +1,12 @@
+Description: Run TruffleHog against collected artifacts to detect potential secrets
+Category: Credentials
+Author: Aashiq Ahmed
+Version: 1.0
+Id: 41f5c5e8-7a5b-4b3e-9c3d-2d8f3a9d4b72
+BinaryUrl: https://github.com/trufflesecurity/trufflehog/releases/latest
+ExportFormat: json
+
+Processors:
+  -
+    Executable: TruffleHog\trufflehog.exe
+    CommandLine: filesystem "%sourceDirectory%" --json > "%destinationDirectory%\trufflehog_results.json"


### PR DESCRIPTION
This module runs TruffleHog against artifacts collected by KAPE to detect
potential secrets such as API keys, tokens, and credentials.

It can be used with any KAPE artifact collection but is especially useful
with credential-related targets.

Users should place trufflehog.exe under:

KAPE\Modules\bin\TruffleHog\