### PR TITLE
Add SSHTunnelCommandArtifacts target for collecting SSH tunneling artifacts

### DIFF
--- a/Targets/Apps/SSHTunnelCommandArtifacts.tkape
+++ b/Targets/Apps/SSHTunnelCommandArtifacts.tkape
@@ -32,7 +32,7 @@ Targets:
     Name: User PowerShell scripts
     Category: Scripts
     Path: C:\Users\%user%
-    FileMask: *.ps1
+    FileMask: "*.ps1"
     Recursive: true
     Comment: User-created PowerShell scripts may contain pivoting commands
 

--- a/Targets/Apps/SSHTunnelCommandArtifacts.tkape
+++ b/Targets/Apps/SSHTunnelCommandArtifacts.tkape
@@ -40,7 +40,7 @@ Targets:
     Name: User batch scripts
     Category: Scripts
     Path: C:\Users\%user%
-    FileMask: *.bat
+    FileMask: "*.bat"
     Recursive: true
     Comment: Batch scripts may contain ssh, plink, or netsh portproxy commands
 
@@ -48,7 +48,7 @@ Targets:
     Name: User command scripts
     Category: Scripts
     Path: C:\Users\%user%
-    FileMask: *.cmd
+    FileMask: "*.cmd"
     Recursive: true
     Comment: CMD scripts may contain ssh, plink, or netsh portproxy commands
 
@@ -56,14 +56,6 @@ Targets:
     Name: User shell scripts
     Category: Scripts
     Path: C:\Users\%user%
-    FileMask: *.sh
+    FileMask: "*.sh"
     Recursive: true
     Comment: Shell scripts may contain ssh tunneling and proxy commands
-
-  -
-    Name: User log files
-    Category: Logs
-    Path: C:\Users\%user%
-    FileMask: *.log
-    Recursive: true
-    Comment: User log files may contain pivot tool execution details

--- a/Targets/Apps/SSHTunnelCommandArtifacts.tkape
+++ b/Targets/Apps/SSHTunnelCommandArtifacts.tkape
@@ -83,3 +83,6 @@ Targets:
     FileMask: "*"
     Recursive: true
     Comment: SSH directory may contain keys, configs, and other connection artifacts
+
+# Documentation
+# N/A

--- a/Targets/Apps/SSHTunnelCommandArtifacts.tkape
+++ b/Targets/Apps/SSHTunnelCommandArtifacts.tkape
@@ -2,7 +2,7 @@ Description: Collect command history, scripts, and SSH client artifacts useful f
 Author: Aashiq Ahmed
 Version: 1.0
 Id: 4d7c1c5b-7b9d-4c8c-a8dd-2f7d51b29011
-
+RecreateDirectories: true
 Targets:
   -
     Name: PowerShell ConsoleHost history

--- a/Targets/Apps/SSHTunnelCommandArtifacts.tkape
+++ b/Targets/Apps/SSHTunnelCommandArtifacts.tkape
@@ -1,0 +1,69 @@
+Description: Collect command history and script artifacts useful for identifying SSH tunneling and pivoting commands
+Author: Aashiq Ahmed
+Version: 1.0
+Id: 4d7c1c5b-7b9d-4c8c-a8dd-2f7d51b29011
+
+Targets:
+  -
+    Name: PowerShell ConsoleHost history
+    Category: CommandHistory
+    Path: C:\Users\%user%\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadLine
+    FileMask: ConsoleHost_history.txt
+    Recursive: true
+    Comment: PowerShell command history may contain ssh, plink, and pivot tool commands
+
+  -
+    Name: Bash history in user profiles
+    Category: CommandHistory
+    Path: C:\Users\%user%
+    FileMask: .bash_history
+    Recursive: true
+    Comment: Bash history may contain ssh tunneling and pivot commands
+
+  -
+    Name: Zsh history in user profiles
+    Category: CommandHistory
+    Path: C:\Users\%user%
+    FileMask: .zsh_history
+    Recursive: true
+    Comment: Zsh history may contain ssh tunneling and pivot commands
+
+  -
+    Name: User PowerShell scripts
+    Category: Scripts
+    Path: C:\Users\%user%
+    FileMask: *.ps1
+    Recursive: true
+    Comment: User-created PowerShell scripts may contain pivoting commands
+
+  -
+    Name: User batch scripts
+    Category: Scripts
+    Path: C:\Users\%user%
+    FileMask: *.bat
+    Recursive: true
+    Comment: Batch scripts may contain ssh, plink, or netsh portproxy commands
+
+  -
+    Name: User command scripts
+    Category: Scripts
+    Path: C:\Users\%user%
+    FileMask: *.cmd
+    Recursive: true
+    Comment: CMD scripts may contain ssh, plink, or netsh portproxy commands
+
+  -
+    Name: User shell scripts
+    Category: Scripts
+    Path: C:\Users\%user%
+    FileMask: *.sh
+    Recursive: true
+    Comment: Shell scripts may contain ssh tunneling and proxy commands
+
+  -
+    Name: User log files
+    Category: Logs
+    Path: C:\Users\%user%
+    FileMask: *.log
+    Recursive: true
+    Comment: User log files may contain pivot tool execution details

--- a/Targets/Apps/SSHTunnelCommandArtifacts.tkape
+++ b/Targets/Apps/SSHTunnelCommandArtifacts.tkape
@@ -1,4 +1,4 @@
-Description: Collect command history and script artifacts useful for identifying SSH tunneling and pivoting commands
+Description: Collect command history, scripts, and SSH client artifacts useful for identifying SSH tunneling and pivoting commands
 Author: Aashiq Ahmed
 Version: 1.0
 Id: 4d7c1c5b-7b9d-4c8c-a8dd-2f7d51b29011
@@ -59,3 +59,27 @@ Targets:
     FileMask: "*.sh"
     Recursive: true
     Comment: Shell scripts may contain ssh tunneling and proxy commands
+
+  -
+    Name: SSH known_hosts
+    Category: SSH
+    Path: C:\Users\%user%\.ssh
+    FileMask: known_hosts
+    Recursive: false
+    Comment: known_hosts records SSH servers previously connected to
+
+  -
+    Name: SSH config
+    Category: SSH
+    Path: C:\Users\%user%\.ssh
+    FileMask: config
+    Recursive: false
+    Comment: SSH config may contain port forwarding or tunneling settings
+
+  -
+    Name: SSH directory artifacts
+    Category: SSH
+    Path: C:\Users\%user%\.ssh
+    FileMask: "*"
+    Recursive: true
+    Comment: SSH directory may contain keys, configs, and other connection artifacts


### PR DESCRIPTION
This target collects command history and related script artifacts that may reveal SSH tunneling, port forwarding, and pivoting activity on a system.

It gathers PowerShell, Bash, and other shell history files that frequently contain commands such as `ssh -L`, `ssh -R`, `plink`, `chisel`, `ngrok`, and other tunneling utilities used during lateral movement or covert access.

These artifacts can help investigators quickly identify tunneling activity during incident response or threat hunting.
