### PR TITLE
Fixed non-escaped double quotes on PowerShell_DLL_List.mkape

### DIFF
--- a/Modules/Windows/PowerShell_DLL_List.mkape
+++ b/Modules/Windows/PowerShell_DLL_List.mkape
@@ -1,13 +1,13 @@
 Description: DLL List
 Category: LiveResponse
-Author: nov3mb3r
-Version: 1.0
+Author: nov3mb3r, JorZay
+Version: 1.1
 Id: 19e6448f-f94b-49a4-bc16-26080b7c0592
 ExportFormat: txt
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "gps | Format-List ProcessName, @{l="Modules";e={$_.Modules|Out-String}}"
+        CommandLine: -Command "gps | Format-List ProcessName, @{l=\"Modules\";e={$_.Modules|Out-String}}"
         ExportFormat: txt
         ExportFile: dlllist.txt
 


### PR DESCRIPTION
Non-escaped double-quotes were preventing the module from properly executing:
" Modules : The term 'Modules' is not recognized as the name of a cmdlet, function, script file, or operable program.     Check the spelling of the name, or if a path was included, verify that the path is correct and try again.               At line:1 char:36                                                                                                       + gps | Format-List ProcessName, @{l=Modules;e={$_.Modules|Out-String}}                                                 +                                    ~~~~~~~                                                                                + CategoryInfo          : ObjectNotFound: (Modules:String) [], CommandNotFoundException                                 + FullyQualifiedErrorId : CommandNotFoundException                                                                                                                                     "

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have generated a unique `GUID` for my Target(s)/Module(s)
- [ ] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [x] I have set or updated the version of my Target(s)/Module(s)
- [x] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [x] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [ ] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [x] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format

If your submission involves an SQLite database, have you considered making an [SQLECmd Map](https://github.com/EricZimmerman/SQLECmd/tree/master/SQLMap/Maps) for the SQLite database? If you make a Map, please add the SQLite database to the [SQLiteDatabases.tkape Compound Target](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/Compound/SQLiteDatabases.tkape).

Thank you for your submission and for contributing to the DFIR community!
