### PR TITLE
Add AI coding agent targets (Claude Code, Codex, Copilot, Gemini CLI, OpenCode, Cursor, Cline, Roo Code) and AICodingAgents compound

### DIFF
--- a/Targets/Apps/ClaudeCode.tkape
+++ b/Targets/Apps/ClaudeCode.tkape
@@ -1,0 +1,237 @@
+Description: Claude Code (Anthropic agentic coding CLI) session transcripts, prompt history, configuration, hooks, and IDE integration artifacts
+Author: Eric Capuano
+Version: 1.0
+Id: 4c41d4f8-faf9-42ac-a3ae-4d6dfe230698
+RecreateDirectories: true
+Targets:
+    -
+        Name: Claude Code Global State
+        Category: Apps
+        Path: C:\Users\%user%\
+        FileMask: ".claude.json*"
+        Comment: 'Global app state. Contains configured MCP servers, per-project allowed tools and trust decisions, list of every project directory Claude Code has been run in, OAuth account metadata (email/org, no tokens), install method, and usage counters. Backup copies match .claude.json.backup*'
+    -
+        Name: Claude Code Session Transcripts
+        Category: Apps
+        Path: C:\Users\%user%\.claude\projects\
+        Recursive: true
+        Comment: 'One subfolder per project (path with separators replaced by dashes). Each session is <sessionId>.jsonl containing every user prompt, assistant response, tool call and tool result. Subfolders per session hold subagent transcripts (subagents\agent-*.jsonl), oversized tool outputs (tool-results\), session-memory summaries and the per-project auto memory (memory\*.md)'
+    -
+        Name: Claude Code Prompt History
+        Category: Apps
+        Path: C:\Users\%user%\.claude\
+        FileMask: "history.jsonl"
+        Comment: 'Global index of every prompt typed into Claude Code with timestamp, project path, and pasted content references'
+    -
+        Name: Claude Code User Settings
+        Category: Apps
+        Path: C:\Users\%user%\.claude\
+        FileMask: "settings*.json"
+        Comment: 'settings.json and settings.local.json: permission allow/deny lists, hooks, environment variables, enabled plugins, model and telemetry configuration'
+    -
+        Name: Claude Code User Instructions
+        Category: Apps
+        Path: C:\Users\%user%\.claude\
+        FileMask: "CLAUDE.md"
+        Comment: 'User-level instructions loaded into every session'
+    -
+        Name: Claude Code Keybindings
+        Category: Apps
+        Path: C:\Users\%user%\.claude\
+        FileMask: "keybindings.json"
+        Comment: 'Custom keyboard shortcuts'
+    -
+        Name: Claude Code Stats Cache
+        Category: Apps
+        Path: C:\Users\%user%\.claude\
+        FileMask: "stats-cache.json"
+        Comment: 'Aggregated usage statistics (sessions, messages, tokens, models used per day)'
+    -
+        Name: Claude Code Hooks
+        Category: Apps
+        Path: C:\Users\%user%\.claude\hooks\
+        Recursive: true
+        Comment: 'User-defined scripts executed automatically on tool use, prompt submit, session start/stop, etc. Review for persistence or data exfiltration'
+    -
+        Name: Claude Code Commands
+        Category: Apps
+        Path: C:\Users\%user%\.claude\commands\
+        Recursive: true
+        Comment: 'User-defined slash commands (markdown prompts)'
+    -
+        Name: Claude Code Skills
+        Category: Apps
+        Path: C:\Users\%user%\.claude\skills\
+        Recursive: true
+        Comment: 'User-installed skills (SKILL.md plus supporting scripts). Can be large if many skills are installed'
+    -
+        Name: Claude Code Agents
+        Category: Apps
+        Path: C:\Users\%user%\.claude\agents\
+        Recursive: true
+        Comment: 'User-defined subagent definitions and their persistent agent-memory'
+    -
+        Name: Claude Code Rules
+        Category: Apps
+        Path: C:\Users\%user%\.claude\rules\
+        Recursive: true
+        Comment: 'User-level rule files loaded into every project'
+    -
+        Name: Claude Code Workflows
+        Category: Apps
+        Path: C:\Users\%user%\.claude\workflows\
+        Recursive: true
+        Comment: 'User-level dynamic workflow scripts that orchestrate subagents'
+    -
+        Name: Claude Code Plugin Configuration
+        Category: Apps
+        Path: C:\Users\%user%\.claude\plugins\
+        FileMask: "*.json"
+        Comment: 'installed_plugins.json, known_marketplaces.json, blocklist.json, config.json and plugin-catalog-cache.json. Records which third-party plugins and marketplaces were installed and from where. Plugin source trees under plugins\cache and plugins\repos are intentionally not collected'
+    -
+        Name: Claude Code Shell Snapshots
+        Category: Apps
+        Path: C:\Users\%user%\.claude\shell-snapshots\
+        Recursive: true
+        Comment: 'Snapshot of the user''s shell environment (functions, aliases, PATH) captured at session start. One file per session'
+    -
+        Name: Claude Code File History
+        Category: Apps
+        Path: C:\Users\%user%\.claude\file-history\
+        Recursive: true
+        Comment: 'Pre-edit copies of files modified by Claude Code, organized by session ID with versioned entries (<hash>@v1, @v2...). Allows reconstruction of what the agent changed'
+    -
+        Name: Claude Code Todos
+        Category: Apps
+        Path: C:\Users\%user%\.claude\todos\
+        Recursive: true
+        Comment: 'Per-session task lists (older versions)'
+    -
+        Name: Claude Code Tasks
+        Category: Apps
+        Path: C:\Users\%user%\.claude\tasks\
+        Recursive: true
+        Comment: 'Per-session task state, background task output and lock files (newer versions)'
+    -
+        Name: Claude Code Plans
+        Category: Apps
+        Path: C:\Users\%user%\.claude\plans\
+        Recursive: true
+        Comment: 'Plan-mode documents written before implementation'
+    -
+        Name: Claude Code Sessions
+        Category: Apps
+        Path: C:\Users\%user%\.claude\sessions\
+        FileMask: "*.json"
+        Comment: 'Live session registry keyed by PID: session ID, working directory, start time, and connected IDE. Per-session .key files are not collected'
+    -
+        Name: Claude Code IDE Locks
+        Category: Apps
+        Path: C:\Users\%user%\.claude\ide\
+        FileMask: "*.lock"
+        Comment: 'IDE integration lock files, one per IDE extension instance, containing the IDE PID, workspace folders and auth token used for the local IDE bridge'
+    -
+        Name: Claude Code Debug Logs
+        Category: Apps
+        Path: C:\Users\%user%\.claude\debug\
+        Recursive: true
+        Comment: 'Per-session debug logs when present'
+    -
+        Name: Claude Code Paste Cache
+        Category: Apps
+        Path: C:\Users\%user%\.claude\paste-cache\
+        Recursive: true
+        Comment: 'Content pasted into the prompt that was too large to inline in history.jsonl'
+    -
+        Name: Claude Code Session Environment
+        Category: Apps
+        Path: C:\Users\%user%\.claude\session-env\
+        Recursive: true
+        Comment: 'Per-session environment variable overrides'
+    -
+        Name: Claude Code Settings Backups
+        Category: Apps
+        Path: C:\Users\%user%\.claude\backups\
+        Recursive: true
+        Comment: 'Automatic backups of settings files, named by epoch millisecond timestamp'
+    -
+        Name: Claude Code Telemetry Cache
+        Category: Apps
+        Path: C:\Users\%user%\.claude\statsig\
+        Recursive: true
+        Comment: 'Feature-flag and telemetry cache containing stable device ID and last session metadata'
+    -
+        Name: Claude Code VS Code Extension Storage
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\anthropic.claude-code\
+        Recursive: true
+        Comment: 'Global storage for the Claude Code VS Code extension (publisher.name anthropic.claude-code)'
+    -
+        Name: Claude Code Cursor Extension Storage
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\User\globalStorage\anthropic.claude-code\
+        Recursive: true
+        Comment: 'Global storage for the Claude Code extension when installed in Cursor'
+    -
+        Name: Claude Desktop Embedded Claude Code Sessions
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Claude\claude-code-sessions\
+        Recursive: true
+        Comment: 'Claude Code sessions launched from the Claude Desktop app (Code tab). Organized by account and session ID'
+    -
+        Name: Claude Desktop Cowork Agent Sessions
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Claude\local-agent-mode-sessions\
+        Recursive: true
+        Comment: 'Claude Desktop Cowork (local agent mode) session state. One JSON per turn plus spaces.json. Cowork runs the Claude Code agent against local files'
+    -
+        Name: Claude Desktop MCP Configuration
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Claude\
+        FileMask: "claude_desktop_config.json"
+        Comment: 'MCP servers configured for Claude Desktop, which are also exposed to embedded Claude Code and Cowork sessions'
+    -
+        Name: Claude Desktop Embedded Claude Code Sessions (MSIX)
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude-code-sessions\
+        Recursive: true
+        Comment: 'Same as above for Microsoft Store / MSIX installs of Claude Desktop, where AppData\Roaming is virtualized under the package LocalCache'
+    -
+        Name: Claude Desktop Cowork Agent Sessions (MSIX)
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\local-agent-mode-sessions\
+        Recursive: true
+        Comment: 'Same as above for Microsoft Store / MSIX installs of Claude Desktop'
+    -
+        Name: Claude Desktop MCP Configuration (MSIX)
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Local\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\
+        FileMask: "claude_desktop_config.json"
+        Comment: 'Same as above for Microsoft Store / MSIX installs of Claude Desktop'
+
+# Documentation
+# https://code.claude.com/docs/en/claude-directory - Official reference for the ~/.claude directory layout
+# https://code.claude.com/docs/en/settings - Settings, permissions and environment variables
+# https://code.claude.com/docs/en/hooks - Hook configuration and lifecycle events
+# https://code.claude.com/docs/en/memory - CLAUDE.md and auto memory
+# https://github.com/anthropics/claude-code
+# https://github.com/anthropics/claude-code/issues/26073 - MSIX virtualized AppData path for Claude Desktop
+#
+# Claude Code stores its state under %USERPROFILE%\.claude\ (C:\Users\<user>\.claude\) plus a single %USERPROFILE%\.claude.json.
+# If the CLAUDE_CONFIG_DIR environment variable is set, everything under .claude\ lives in that directory instead; check
+# the user's environment variables (registry: HKU\<SID>\Environment) if the default location is empty.
+#
+# Primary evidence of use is projects\<project-slug>\<sessionId>.jsonl. Each line is a JSON record with type
+# (user, assistant, system, summary, etc), uuid, parentUuid, sessionId, cwd, gitBranch, version, timestamp and the
+# full message content including tool_use inputs (commands run, files written) and tool_result outputs.
+# history.jsonl provides a quick cross-project timeline of prompts. file-history\ contains the pre-edit copies
+# of every file the agent modified, keyed by session ID.
+#
+# Project-level configuration also exists inside individual repositories (<repo>\CLAUDE.md, <repo>\.claude\settings.json,
+# <repo>\.claude\settings.local.json, <repo>\.mcp.json). Those are not collected here because their locations are
+# arbitrary; the project list in .claude.json and the projects\ folder names identify which directories to examine.
+#
+# Deliberately not collected: .claude\.credentials.json (OAuth tokens), .claude\sessions\*.key, and the plugin
+# source trees under .claude\plugins\cache and .claude\plugins\repos (large, reproducible from the recorded marketplace URLs).
+# Folder names for the Claude Desktop embedded sessions were verified against the macOS build (Application Support\Claude)
+# and mapped to the equivalent Windows AppData\Roaming\Claude location.

--- a/Targets/Apps/Cline.tkape
+++ b/Targets/Apps/Cline.tkape
@@ -1,0 +1,98 @@
+Description: Cline (VS Code AI coding agent) task conversation histories, MCP settings, checkpoints, and global state
+Author: Eric Capuano
+Version: 1.0
+Id: 3d257046-3294-47af-a66e-b95577184c1d
+RecreateDirectories: true
+Targets:
+    -
+        Name: Cline Tasks
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\tasks\
+        Recursive: true
+        Comment: 'One folder per task ID containing api_conversation_history.json (full model conversation including tool calls and results), ui_messages.json, task_metadata.json, context_history.json'
+    -
+        Name: Cline Settings
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\settings\
+        Recursive: true
+        Comment: 'cline_mcp_settings.json (configured MCP servers) and other settings'
+    -
+        Name: Cline State
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\state\
+        Recursive: true
+        Comment: 'taskHistory.json index of all tasks with timestamps, workspace and token usage'
+    -
+        Name: Cline Checkpoints
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\checkpoints\
+        Recursive: true
+        Comment: 'Shadow git repositories holding workspace snapshots between agent edits. Can be large'
+    -
+        Name: Cline Cache
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\cache\
+        Recursive: true
+        Comment: 'cline_recommended_models.json and remote_config_<orgId>.json'
+    -
+        Name: Cline Global State
+        Category: Apps
+        Path: C:\Users\%user%\.cline\data\
+        FileMask: 'globalState.json'
+        Comment: 'Provider configuration, selected models, and feature state (Cline 4.x moved this out of VS Code storage)'
+    -
+        Name: Cline Workspace State
+        Category: Apps
+        Path: C:\Users\%user%\.cline\data\workspaces\
+        Recursive: true
+        Comment: 'workspaceState.json per hashed workspace'
+    -
+        Name: Cline SDK Sessions
+        Category: Apps
+        Path: C:\Users\%user%\.cline\data\sessions\
+        Recursive: true
+        Comment: 'Session manifests and message files for CLI/SDK-driven sessions'
+    -
+        Name: Cline Logs
+        Category: Apps
+        Path: C:\Users\%user%\.cline\data\logs\
+        Recursive: true
+        Comment: 'hub-daemon.log and other runtime logs'
+    -
+        Name: Cline User MCP Servers
+        Category: Apps
+        Path: C:\Users\%user%\Documents\Cline\MCP\
+        Recursive: true
+        Comment: 'MCP servers built or installed by Cline for the user'
+    -
+        Name: Cline User Rules
+        Category: Apps
+        Path: C:\Users\%user%\Documents\Cline\Rules\
+        Recursive: true
+        Comment: 'Global rule files loaded into every task'
+    -
+        Name: Cline User Workflows
+        Category: Apps
+        Path: C:\Users\%user%\Documents\Cline\Workflows\
+        Recursive: true
+        Comment: 'Global workflow definitions'
+    -
+        Name: Cline User Hooks
+        Category: Apps
+        Path: C:\Users\%user%\Documents\Cline\Hooks\
+        Recursive: true
+        Comment: 'Hook scripts executed on lifecycle events. Review for persistence or data exfiltration'
+
+# Documentation
+# https://github.com/cline/cline/blob/main/apps/vscode/src/core/storage/disk.ts - tasks\<id>\ file names, settings\, cache\, Documents\Cline\ paths
+# https://github.com/cline/cline/blob/main/apps/vscode/src/shared/storage/storage-context.ts - %USERPROFILE%\.cline\data layout (CLINE_DATA_DIR / CLINE_DIR overrides)
+# https://github.com/cline/cline/blob/main/apps/vscode/src/hosts/vscode/vscode-to-file-migration.ts - state\taskHistory.json and checkpoints\ locations
+# https://github.com/cline/cline/blob/main/apps/vscode/package.json - publisher saoudrizwan, name claude-dev
+# https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostStoragePaths.ts - globalStorage\<extension id lowercased>
+#
+# Cline stores task data in the VS Code extension globalStorage folder %APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\
+# (extension ID lowercased) and, since 4.x, its global state and secrets under %USERPROFILE%\.cline\data\
+# (override: CLINE_DATA_DIR or CLINE_DIR). The VS Code User folder is %APPDATA%\Code\User by default;
+# Cline installed in Cursor or VSCodium would be under that editor's equivalent User\globalStorage.
+#
+# Deliberately not collected: .cline\data\secrets.json (API keys).

--- a/Targets/Apps/Cursor.tkape
+++ b/Targets/Apps/Cursor.tkape
@@ -1,0 +1,142 @@
+Description: Cursor AI editor agent chat history, composer data, local file history, MCP and hook configuration, and logs
+Author: Eric Capuano
+Version: 1.0
+Id: f490d529-091c-47af-ba00-becdb4fc7a3f
+RecreateDirectories: true
+Targets:
+    -
+        Name: Cursor Global State Database
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\User\globalStorage\
+        FileMask: 'state.vscdb*'
+        Comment: 'SQLite ItemTable and cursorDiskKV tables. cursorDiskKV holds agent/composer conversations as composerData:<composerId> and bubbleId:<composerId>:<bubbleId> records, checkpointId:* and messageRequestContext:* entries. Includes -wal, -shm and .backup files'
+    -
+        Name: Cursor Global Storage JSON
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\User\globalStorage\
+        FileMask: 'storage.json'
+        Comment: 'Window state, recently opened workspaces and files'
+    -
+        Name: Cursor Workspace State Databases
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\User\workspaceStorage\*\
+        FileMask: 'state.vscdb*'
+        Comment: 'Per-workspace ItemTable with composer.composerData (list of conversations for the workspace), aiService.prompts and legacy workbench.panel.aichat.view.aichat.chatdata'
+    -
+        Name: Cursor Workspace Mapping
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\User\workspaceStorage\*\
+        FileMask: 'workspace.json'
+        Comment: 'Maps each hashed workspaceStorage folder back to the workspace folder path'
+    -
+        Name: Cursor Local File History
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\User\History\
+        Recursive: true
+        Comment: 'Timeline copies of edited files (VS Code local history), including agent-driven edits'
+    -
+        Name: Cursor Unsaved Backups
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\Backups\
+        Recursive: true
+        Comment: 'Hot-exit backups of unsaved editor contents'
+    -
+        Name: Cursor User Settings
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\User\
+        FileMask: 'settings.json'
+        Comment: 'User settings'
+    -
+        Name: Cursor Logs
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\logs\
+        Recursive: true
+        Comment: 'Per-launch log folders (yyyyMMddTHHmmss) with main.log, renderer.log, exthost logs for anysphere.cursor-agent-exec, anysphere.cursor-mcp, cursor.hooks.*.log and cursor.requestTraces.log'
+    -
+        Name: Cursor Machine ID
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Cursor\
+        FileMask: 'machineid'
+        Comment: 'Stable machine identifier sent with telemetry'
+    -
+        Name: Cursor Agent Transcripts
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\projects\*\agent-transcripts\
+        Recursive: true
+        Comment: 'Per-project agent conversation transcripts as <conversationId>\<conversationId>.jsonl'
+    -
+        Name: Cursor Project Terminals
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\projects\*\terminals\
+        Recursive: true
+        Comment: 'Captured terminal output from agent-run commands'
+    -
+        Name: Cursor Project MCP Data
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\projects\*\mcps\
+        Recursive: true
+        Comment: 'Per-project MCP server state'
+    -
+        Name: Cursor AI Code Tracking
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\ai-tracking\
+        FileMask: 'ai-code-tracking.db*'
+        Comment: 'SQLite database attributing code changes to AI versus human authorship'
+    -
+        Name: Cursor MCP Configuration
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\
+        FileMask: 'mcp.json'
+        Comment: 'User-level MCP servers (commands, URLs, env)'
+    -
+        Name: Cursor Hooks
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\
+        FileMask: 'hooks.json'
+        Comment: 'User-level agent hooks executed on lifecycle events. Review for persistence or data exfiltration'
+    -
+        Name: Cursor Hook Scripts
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\hooks\
+        Recursive: true
+        Comment: 'Scripts referenced by hooks.json'
+    -
+        Name: Cursor Startup Arguments
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\
+        FileMask: 'argv.json'
+        Comment: 'Runtime arguments'
+    -
+        Name: Cursor Agents
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\agents\
+        Recursive: true
+        Comment: 'Custom agent definitions'
+    -
+        Name: Cursor Installed Extensions List
+        Category: Apps
+        Path: C:\Users\%user%\.cursor\extensions\
+        FileMask: 'extensions.json'
+        Comment: 'Installed extension identifiers and versions'
+    -
+        Name: Cursor Enterprise Hooks
+        Category: Apps
+        Path: C:\ProgramData\Cursor\
+        FileMask: 'hooks.json'
+        Comment: 'Machine-wide hooks configured by administrators'
+
+# Documentation
+# https://docs.specstory.com/faqs - Windows path of globalStorage\state.vscdb holding Cursor chat history
+# https://github.com/Callum-Ward/cursaves/blob/main/docs/how-cursor-stores-chats.md - cursorDiskKV keys (composerData, bubbleId, checkpointId, messageRequestContext)
+# https://cursor.com/docs/mcp - %USERPROFILE%\.cursor\mcp.json
+# https://cursor.com/docs/hooks - hooks.json locations including C:\ProgramData\Cursor\hooks.json, transcript_path
+# https://forum.cursor.com/t/accessing-the-full-agent-transcript-in-cursor/157311 - agent-transcripts JSONL location (confirmed by Cursor staff)
+# https://github.com/microsoft/vscode/blob/main/src/vs/platform/storage/electron-main/storageMain.ts - state.vscdb (Cursor is a VS Code fork)
+#
+# Cursor keeps VS Code-style user data under %APPDATA%\Cursor\ and Cursor-specific agent data under %USERPROFILE%\.cursor\.
+# Both roots, User\globalStorage\state.vscdb, User\workspaceStorage\<hash>\state.vscdb + workspace.json, User\History,
+# Backups, logs\<timestamp>\, machineid, and .cursor\{agents,ai-tracking\ai-code-tracking.db,plugins,projects\<slug>\{canvases,mcps,terminals},argv.json,extensions\extensions.json}
+# were confirmed on Windows Server 2025 with a fresh Cursor install (winget Anysphere.Cursor).
+# Agent conversations are stored in globalStorage\state.vscdb (cursorDiskKV table); per-workspace state.vscdb lists which
+# conversations belong to which folder. Full agent transcripts are also written as JSONL under .cursor\projects\<encoded path>\agent-transcripts\.
+# The .cursor\projects\<slug>\canvases\ folder can contain node_modules and is not collected.

--- a/Targets/Apps/GeminiCLI.tkape
+++ b/Targets/Apps/GeminiCLI.tkape
@@ -1,0 +1,126 @@
+Description: Google Gemini CLI chat session logs, prompt history, shell history, checkpoints, and configuration
+Author: Eric Capuano
+Version: 1.0
+Id: 25f36466-14ec-4d70-988d-07d755abd14c
+RecreateDirectories: true
+Targets:
+    -
+        Name: Gemini CLI Project Temp and Chat History
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\tmp\
+        Recursive: true
+        Comment: 'One folder per project (slug of folder name on current builds, sha256 of the path on older builds). Each holds .project_root (absolute project path), chats\session-<timestamp>-<id>.jsonl or .json (full conversation with tool calls), logs.json (prompt history), shell_history (commands run via !), checkpoints\ and checkpoint-<tag>.json, memory\, plans\, tasks\. tmp\bin\ holds downloaded helper binaries'
+    -
+        Name: Gemini CLI Project Registry
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'projects.json'
+        Comment: 'Maps absolute project paths to the slug folder names used under tmp\ and history\'
+    -
+        Name: Gemini CLI Settings
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'settings.json'
+        Comment: 'User settings including auth method, MCP servers, hooks, tool allow lists'
+    -
+        Name: Gemini CLI Trusted Folders
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'trustedFolders.json'
+        Comment: 'Folders the user marked as trusted'
+    -
+        Name: Gemini CLI Installation ID
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'installation_id'
+        Comment: 'Random UUID identifying the install'
+    -
+        Name: Gemini CLI Google Accounts
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'google_accounts.json'
+        Comment: 'Cached Google account identity used for login (no tokens)'
+    -
+        Name: Gemini CLI MCP Server Enablement
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'mcp-server-enablement.json'
+        Comment: 'Which configured MCP servers are enabled'
+    -
+        Name: Gemini CLI Global Context
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'GEMINI.md'
+        Comment: 'User-level instructions loaded into every session'
+    -
+        Name: Gemini CLI Keybindings
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\
+        FileMask: 'keybindings.json'
+        Comment: 'Custom keybindings'
+    -
+        Name: Gemini CLI Commands
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\commands\
+        Recursive: true
+        Comment: 'User custom slash commands (*.toml)'
+    -
+        Name: Gemini CLI Policies
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\policies\
+        Recursive: true
+        Comment: 'Policy engine rules controlling tool approval (*.toml, including auto-saved.toml)'
+    -
+        Name: Gemini CLI Skills
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\skills\
+        Recursive: true
+        Comment: 'User-installed skills'
+    -
+        Name: Gemini CLI Agents
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\agents\
+        Recursive: true
+        Comment: 'Custom subagent definitions'
+    -
+        Name: Gemini CLI Acknowledgments
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\acknowledgments\
+        Recursive: true
+        Comment: 'Agents the user acknowledged'
+    -
+        Name: Gemini CLI Extension Manifests
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\extensions\
+        FileMask: '*.json'
+        Recursive: true
+        Comment: 'gemini-extension.json and .gemini-extension-install.json per extension recording source URL and install type. Extension code is not collected'
+    -
+        Name: Gemini CLI Checkpoint Shadow Repositories
+        Category: Apps
+        Path: C:\Users\%user%\.gemini\history\
+        Recursive: true
+        Comment: 'Shadow git repositories holding file snapshots taken before tool edits (checkpointing). Can be large'
+    -
+        Name: Gemini CLI System Settings
+        Category: Apps
+        Path: C:\ProgramData\gemini-cli\
+        Recursive: true
+        Comment: 'Enterprise system-level settings.json and policies'
+
+# Documentation
+# https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/config/storage.ts - All path definitions (getGlobalGeminiDir, getProjectTempDir, getHistoryDir, getSystemConfigDir)
+# https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/utils/paths.ts - GEMINI_DIR and GEMINI_CLI_HOME override
+# https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/chatRecordingService.ts - chats\session-*.jsonl format
+# https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/config/projectRegistry.ts - projects.json slug registry and .project_root marker
+# https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/session-management.md
+# https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/checkpointing.md
+#
+# Gemini CLI stores its state under %USERPROFILE%\.gemini\ (override: GEMINI_CLI_HOME). The root, projects.json, tmp\<slug>\.project_root
+# and history\<slug>\ were confirmed on Windows Server 2025 with Gemini CLI 0.58.0. Chat logs are written as
+# tmp\<project>\chats\session-<YYYY-MM-DDTHH-MM>-<first 8 of sessionId>.jsonl (first line is session metadata, then one JSON
+# record per message including tool calls). Older builds wrote a single session-*.json object and named the project folder
+# by sha256 of its path; both patterns are covered by the recursive tmp\ entry.
+#
+# Deliberately not collected: oauth_creds.json, mcp-oauth-tokens.json, a2a-oauth-tokens.json and .env (credentials),
+# cli-browser-profile\ (Chrome profile for the browser agent, large).

--- a/Targets/Apps/GitHubCopilot.tkape
+++ b/Targets/Apps/GitHubCopilot.tkape
@@ -1,0 +1,135 @@
+Description: GitHub Copilot CLI and Copilot Chat (VS Code) agent sessions, prompt history, configuration, and MCP settings
+Author: Eric Capuano
+Version: 1.0
+Id: 7ccbfb16-0bbb-42b0-ac31-3fe86e74e617
+RecreateDirectories: true
+Targets:
+    -
+        Name: Copilot CLI Session State
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\session-state\
+        Recursive: true
+        Comment: 'One folder per session ID containing events.jsonl (every user message, assistant turn, tool execution and result, model change), workspace.yaml (cwd, git root, repository, branch, summary), plan.md, checkpoints\, files\, research\, rewind-file-snapshots\. VS Code-launched sessions also have vscode.metadata.json and a sibling <sessionId>.jsonl'
+    -
+        Name: Copilot CLI Session Store
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\
+        FileMask: 'session-store.db*'
+        Comment: 'SQLite index of sessions (Chronicle) with -wal and -shm sidecars'
+    -
+        Name: Copilot CLI Command History
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\
+        FileMask: 'command-history-state*'
+        Comment: 'Prompt history typed into the CLI (command-history-state.json). Newer builds document a command-history-state directory'
+    -
+        Name: Copilot CLI Command History Directory
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\command-history-state\
+        Recursive: true
+        Comment: 'Prompt history when stored as a directory'
+    -
+        Name: Copilot CLI Configuration
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\
+        FileMask: '*.json'
+        Comment: 'config.json (trusted folders, first launch time), settings.json, mcp-config.json (configured MCP servers), lsp-config.json, permissions-config.json, vscode.session.metadata.cache.json'
+    -
+        Name: Copilot CLI Instructions
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\
+        FileMask: 'copilot-instructions.md'
+        Comment: 'User-level custom instructions loaded into every session'
+    -
+        Name: Copilot CLI Agents
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\agents\
+        Recursive: true
+        Comment: 'Custom agent definitions'
+    -
+        Name: Copilot CLI Skills
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\skills\
+        Recursive: true
+        Comment: 'User-installed skills'
+    -
+        Name: Copilot CLI Hooks
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\hooks\
+        Recursive: true
+        Comment: 'User-defined hook scripts executed on lifecycle events. Review for persistence or data exfiltration'
+    -
+        Name: Copilot CLI Custom Instructions Directory
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\instructions\
+        Recursive: true
+        Comment: 'Additional instruction files'
+    -
+        Name: Copilot CLI Plugin Data
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\plugin-data\
+        Recursive: true
+        Comment: 'State written by installed plugins'
+    -
+        Name: Copilot CLI Logs
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\logs\
+        Recursive: true
+        Comment: 'Per-process log files (process-<epochms>-<pid>.log)'
+    -
+        Name: Copilot CLI IDE Locks
+        Category: Apps
+        Path: C:\Users\%user%\.copilot\ide\
+        FileMask: '*.lock'
+        Comment: 'IDE bridge lock files, one per connected editor instance'
+    -
+        Name: Copilot Chat Extension Storage
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\github.copilot-chat\
+        Recursive: true
+        Comment: 'session-store.db and agent-traces.db SQLite databases (sessions, turns, checkpoints, session_files), plus per-agent working folders'
+    -
+        Name: VS Code Workspace Chat Sessions
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\workspaceStorage\*\chatSessions\
+        Recursive: true
+        Comment: 'Copilot Chat conversation transcripts per workspace, one <sessionId>.json (or .jsonl on newer builds) per chat with requests, responses, tool calls and edits'
+    -
+        Name: VS Code Workspace Chat Editing Sessions
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\workspaceStorage\*\chatEditingSessions\
+        Recursive: true
+        Comment: 'state.json plus contents\ holding pre-edit file snapshots for agent-mode edits, enabling reconstruction of what the agent changed'
+    -
+        Name: VS Code Empty Window Chat Sessions
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\emptyWindowChatSessions\
+        Recursive: true
+        Comment: 'Chat sessions started with no workspace open'
+    -
+        Name: VS Code Transferred Chat Sessions
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\transferredChatSessions\
+        Recursive: true
+        Comment: 'Chat sessions moved between windows or workspaces'
+
+# Documentation
+# https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference - Official list of everything under the Copilot CLI config directory
+# https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli - COPILOT_HOME and COPILOT_CACHE_HOME overrides
+# https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-best-practices - session-state layout (events.jsonl, workspace.yaml, plan.md, checkpoints, files)
+# https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle - session-store.db
+# https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts - chatSessions, emptyWindowChatSessions, transferredChatSessions
+# https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSessionStorage.ts - chatEditingSessions state.json and contents
+# https://github.com/microsoft/vscode/blob/main/extensions/copilot/src/extension/extension/vscode-node/services.ts - github.copilot-chat session-store.db
+#
+# Copilot CLI stores its state under %USERPROFILE%\.copilot\ (override: COPILOT_HOME). Its binary cache lives in
+# %LOCALAPPDATA%\copilot\pkg\ (override: COPILOT_CACHE_HOME) and is not collected. The root location and the
+# session-state, session-store.db, logs and config.json layout were confirmed on Windows Server 2025 with Copilot CLI 1.0.82.
+#
+# Copilot Chat inside VS Code persists conversations through VS Code core chat storage (chatSessions per workspace,
+# emptyWindowChatSessions globally) and the extension keeps its own SQLite session store under globalStorage.
+# The workspaceStorage folder name is an MD5-style hash of the workspace path; the sibling workspace.json (collected by
+# VisualStudioCode.tkape) maps it back to the folder.
+#
+# Deliberately not collected: .copilot\mcp-secrets\ and .copilot\mcp-oauth-config\ (tokens), installed-plugins\ and
+# extensions\ (plugin source trees), %LOCALAPPDATA%\copilot\pkg\ (binary cache).

--- a/Targets/Apps/OpenAICodex.tkape
+++ b/Targets/Apps/OpenAICodex.tkape
@@ -1,0 +1,143 @@
+Description: OpenAI Codex CLI (agentic coding CLI) session rollouts, prompt history, state databases, and configuration
+Author: Eric Capuano
+Version: 1.0
+Id: 306d20f0-f659-47ae-98e6-3e3ab92c5f7c
+RecreateDirectories: true
+Targets:
+    -
+        Name: Codex Session Rollouts
+        Category: Apps
+        Path: C:\Users\%user%\.codex\sessions\
+        Recursive: true
+        Comment: 'Full session transcripts organized as sessions\YYYY\MM\DD\rollout-<timestamp>-<sessionId>.jsonl. Contains session_meta (cwd, cli version, originator, model), every user and assistant message, reasoning summaries, tool/function calls including shell commands and their output'
+    -
+        Name: Codex Archived Session Rollouts
+        Category: Apps
+        Path: C:\Users\%user%\.codex\archived_sessions\
+        Recursive: true
+        Comment: 'Rollout files moved here when a session is archived from the CLI or app'
+    -
+        Name: Codex History and Session Index
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "*.jsonl"
+        Comment: 'history.jsonl (every prompt with session_id and unix timestamp), session_index.jsonl (session ID to thread name and last update), transcription-history.jsonl (voice dictation)'
+    -
+        Name: Codex State Databases
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "*.sqlite*"
+        Comment: 'state_*.sqlite (threads, projects, project_roots, thread_spawn_edges, remote_control_enrollments), thread_history_*.sqlite (thread_items, thread_turns), logs_*.sqlite (application logs), memories_*.sqlite, queue_*.sqlite, goals_*.sqlite and their -wal/-shm files'
+    -
+        Name: Codex Legacy Databases
+        Category: Apps
+        Path: C:\Users\%user%\.codex\sqlite\
+        FileMask: "*.db*"
+        Comment: 'Older codex-dev.db, codex-history-snapshots-dev.db and codex-thread-summaries-dev.db databases'
+    -
+        Name: Codex Configuration
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "config.toml"
+        Comment: 'Model, provider, approval policy, sandbox mode, MCP servers, profiles, and trusted project directories'
+    -
+        Name: Codex Global Instructions
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "AGENTS.md"
+        Comment: 'User-level instructions loaded into every session'
+    -
+        Name: Codex Hooks
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "hooks.json"
+        Comment: 'User-defined hook commands executed on lifecycle events'
+    -
+        Name: Codex Installation Metadata
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "installation_id"
+        Comment: 'Stable per-install identifier'
+    -
+        Name: Codex Version
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "version.json"
+        Comment: 'Installed CLI version and last update check'
+    -
+        Name: Codex External Agent Imports
+        Category: Apps
+        Path: C:\Users\%user%\.codex\
+        FileMask: "*import*.json"
+        Comment: 'external_agent_session_imports.json and claude-cowork-import-history.json: records of sessions imported from other agents (e.g. Claude Code) into Codex'
+    -
+        Name: Codex Rules
+        Category: Apps
+        Path: C:\Users\%user%\.codex\rules\
+        Recursive: true
+        Comment: 'Execution policy rules (.rules files) controlling which commands may run without approval'
+    -
+        Name: Codex Skills
+        Category: Apps
+        Path: C:\Users\%user%\.codex\skills\
+        Recursive: true
+        Comment: 'User-installed skills (SKILL.md plus supporting files)'
+    -
+        Name: Codex Agents
+        Category: Apps
+        Path: C:\Users\%user%\.codex\agents\
+        Recursive: true
+        Comment: 'Custom subagent definitions'
+    -
+        Name: Codex Memories
+        Category: Apps
+        Path: C:\Users\%user%\.codex\memories\
+        Recursive: true
+        Comment: 'Persistent memory notes written by the agent'
+    -
+        Name: Codex Shell Snapshots
+        Category: Apps
+        Path: C:\Users\%user%\.codex\shell_snapshots\
+        Recursive: true
+        Comment: 'Snapshot of the user''s shell environment captured at session start, named <sessionId>.<timestamp>.sh'
+    -
+        Name: Codex Logs
+        Category: Apps
+        Path: C:\Users\%user%\.codex\log\
+        Recursive: true
+        Comment: 'Text logs such as codex-login.log and codex-tui.log'
+    -
+        Name: Codex Thread Writer Locks
+        Category: Apps
+        Path: C:\Users\%user%\.codex\thread-writer-locks\
+        Recursive: true
+        Comment: 'Per-thread lock files indicating sessions that were open'
+    -
+        Name: Codex VS Code Extension Storage
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\openai.chatgpt\
+        Recursive: true
+        Comment: 'Global storage for the Codex VS Code extension (publisher.name openai.chatgpt)'
+
+# Documentation
+# https://github.com/openai/codex
+# https://developers.openai.com/codex/config-reference - config.toml reference
+# https://developers.openai.com/codex/cli/reference - CLI reference including resume/sessions
+# https://github.com/openai/codex/discussions/3827 - Rollout file naming
+# https://ccusage.com/guide/codex/ - Third-party parser documenting sessions\YYYY\MM\DD\rollout-*.jsonl layout
+#
+# Codex stores all state under CODEX_HOME, which defaults to %USERPROFILE%\.codex\ (C:\Users\<user>\.codex\) on Windows.
+# If the CODEX_HOME environment variable is set (it may be a comma-separated list), check those directories instead.
+#
+# Primary evidence of use is sessions\YYYY\MM\DD\rollout-<ISO timestamp>-<uuid>.jsonl. Each line has timestamp, type
+# (session_meta, response_item, event_msg, turn_context, compacted) and payload. session_meta records cwd, cli_version,
+# originator (codex_cli_rs, vscode, codex_desktop, etc), model, and git metadata. response_item function_call entries
+# contain the exact shell commands executed and function_call_output their results.
+# history.jsonl provides a quick cross-session timeline of prompts.
+#
+# Project-level AGENTS.md files and .codex\ folders inside repositories are not collected because their locations are
+# arbitrary; the projects table in state_*.sqlite and the cwd values in session_meta identify which directories to examine.
+#
+# Deliberately not collected: .codex\auth.json (API key / OAuth tokens), .codex\cache\ and .codex\plugins\ (large, reproducible),
+# .codex\tmp\ and .codex\computer-use\ (transient).
+# Layout verified against Codex CLI on macOS; the relative layout under CODEX_HOME is the same on Windows.

--- a/Targets/Apps/OpenCode.tkape
+++ b/Targets/Apps/OpenCode.tkape
@@ -1,0 +1,103 @@
+Description: OpenCode (open-source terminal coding agent) session database, logs, snapshots, and configuration
+Author: Eric Capuano
+Version: 1.0
+Id: 2361bd03-b48c-49c9-b115-66416d665f4b
+RecreateDirectories: true
+Targets:
+    -
+        Name: OpenCode Session Database
+        Category: Apps
+        Path: C:\Users\%user%\.local\share\opencode\
+        FileMask: 'opencode*.db*'
+        Comment: 'SQLite (WAL mode) store with session, message, part, todo, project, project_directory, permission, event, account, credential, workspace tables. Every prompt, response, tool call and result is in message and part. Named opencode.db on release channels, opencode-<channel>.db on dev builds; -wal and -shm sidecars included'
+    -
+        Name: OpenCode Logs
+        Category: Apps
+        Path: C:\Users\%user%\.local\share\opencode\log\
+        Recursive: true
+        Comment: 'opencode.log application log plus direct\<timestamp>-<pid>.jsonl run traces'
+    -
+        Name: OpenCode File Snapshots
+        Category: Apps
+        Path: C:\Users\%user%\.local\share\opencode\snapshot\
+        Recursive: true
+        Comment: 'Bare git directories (snapshot\<projectId>\<worktreeHash>\) holding file-state snapshots taken around agent edits. Can be large'
+    -
+        Name: OpenCode Legacy JSON Storage
+        Category: Apps
+        Path: C:\Users\%user%\.local\share\opencode\storage\
+        Recursive: true
+        Comment: 'Pre-SQLite storage: session\<projectId>\<sessionId>.json, message\<sessionId>\<messageId>.json, part\<messageId>\<partId>.json, project\, session_diff\'
+    -
+        Name: OpenCode Oldest JSON Storage
+        Category: Apps
+        Path: C:\Users\%user%\.local\share\opencode\project\
+        Recursive: true
+        Comment: 'Oldest layout: project\<slug>\storage\session\{info,message,part}\'
+    -
+        Name: OpenCode State
+        Category: Apps
+        Path: C:\Users\%user%\.local\state\opencode\
+        Recursive: true
+        Comment: 'model.json (last used model), plugin-meta.json, locks\<hash>.lock\meta.json (running instances)'
+    -
+        Name: OpenCode User Configuration
+        Category: Apps
+        Path: C:\Users\%user%\.config\opencode\
+        FileMask: '*.json*'
+        Comment: 'opencode.json / opencode.jsonc / config.json (providers, MCP servers, permissions, instructions) and tui.json'
+    -
+        Name: OpenCode User Agents
+        Category: Apps
+        Path: C:\Users\%user%\.config\opencode\agents\
+        Recursive: true
+        Comment: 'Custom agent definitions'
+    -
+        Name: OpenCode User Commands
+        Category: Apps
+        Path: C:\Users\%user%\.config\opencode\commands\
+        Recursive: true
+        Comment: 'Custom slash commands'
+    -
+        Name: OpenCode User Plugins
+        Category: Apps
+        Path: C:\Users\%user%\.config\opencode\plugins\
+        Recursive: true
+        Comment: 'User plugins (JavaScript/TypeScript executed by the agent runtime). Review for malicious behavior'
+    -
+        Name: OpenCode User Skills
+        Category: Apps
+        Path: C:\Users\%user%\.config\opencode\skills\
+        Recursive: true
+        Comment: 'User-installed skills'
+    -
+        Name: OpenCode User Tools
+        Category: Apps
+        Path: C:\Users\%user%\.config\opencode\tools\
+        Recursive: true
+        Comment: 'Custom tool definitions'
+    -
+        Name: OpenCode Home Config Directory
+        Category: Apps
+        Path: C:\Users\%user%\.opencode\
+        Recursive: true
+        Comment: 'Alternate user-level config directory also searched by OpenCode'
+
+# Documentation
+# https://github.com/anomalyco/opencode/blob/dev/packages/core/src/global.ts - Global.Path (data, config, state, cache) built from xdg-basedir
+# https://github.com/anomalyco/opencode/blob/dev/packages/core/src/database/database.ts - opencode.db naming, WAL mode, OPENCODE_DB override
+# https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/snapshot/index.ts - snapshot bare git dirs
+# https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/storage/storage.ts - legacy JSON storage layouts
+# https://opencode.ai/docs/troubleshooting/ - Official Windows locations (%USERPROFILE%\.local\share\opencode)
+#
+# OpenCode uses the xdg-basedir package, which has no Windows branch, so on Windows it writes under the user profile rather
+# than AppData: %USERPROFILE%\.local\share\opencode (data), %USERPROFILE%\.config\opencode (config), %USERPROFILE%\.local\state\opencode
+# (state), %USERPROFILE%\.cache\opencode (cache). XDG_DATA_HOME / XDG_CONFIG_HOME / XDG_STATE_HOME / XDG_CACHE_HOME relocate
+# these; OPENCODE_CONFIG and OPENCODE_CONFIG_DIR point at alternate config. Confirmed on Windows Server 2025 with OpenCode 1.18.26
+# after running a real session: opencode.db, log\opencode.log, .local\state\opencode\locks and .config\opencode\opencode.jsonc were created.
+#
+# Project-level opencode.json(c) and .opencode\ folders live inside repositories and are not collected; the project and
+# project_directory tables in opencode.db list every directory the agent was run in.
+#
+# Deliberately not collected: auth.json and mcp-auth.json (API keys and OAuth tokens), repos\ (cloned plugin sources),
+# .cache\opencode\ (binaries and models.json), %TEMP%\opencode\.

--- a/Targets/Apps/RooCode.tkape
+++ b/Targets/Apps/RooCode.tkape
@@ -1,0 +1,41 @@
+Description: Roo Code (VS Code AI coding agent, archived May 2026) task conversation histories, MCP settings, custom modes, and checkpoints
+Author: Eric Capuano
+Version: 1.0
+Id: 2b3bd9f3-d7bf-4b06-bfbd-85f038ce427e
+RecreateDirectories: true
+Targets:
+    -
+        Name: Roo Code Tasks
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\tasks\
+        Recursive: true
+        Comment: 'tasks\_index.json plus one folder per task ID containing api_conversation_history.json (legacy claude_messages.json), ui_messages.json, task_metadata.json, history_item.json and per-task checkpoints\'
+    -
+        Name: Roo Code Settings
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\
+        Recursive: true
+        Comment: 'mcp_settings.json (configured MCP servers) and custom_modes.yaml'
+    -
+        Name: Roo Code Checkpoints
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\checkpoints\
+        Recursive: true
+        Comment: 'Shadow git repositories per hashed workspace holding snapshots between agent edits. Can be large'
+    -
+        Name: Roo Code Cache
+        Category: Apps
+        Path: C:\Users\%user%\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\cache\
+        Recursive: true
+        Comment: 'Model metadata cache'
+
+# Documentation
+# https://github.com/RooCodeInc/Roo-Code/blob/main/src/utils/storage.ts - getStorageBasePath, tasks\, settings\, cache\ (roo-cline.customStoragePath override)
+# https://github.com/RooCodeInc/Roo-Code/blob/main/src/shared/globalFileNames.ts - file names within a task folder
+# https://github.com/RooCodeInc/Roo-Code/blob/main/src/core/task-persistence/apiMessages.ts - api_conversation_history.json
+# https://github.com/RooCodeInc/Roo-Code/blob/main/src/services/checkpoints/ShadowCheckpointService.ts - checkpoints layout
+# https://github.com/RooCodeInc/Roo-Code/blob/main/src/package.json - publisher RooVeterinaryInc, name roo-cline
+#
+# Roo Code stores everything under the VS Code extension globalStorage folder %APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\
+# unless the roo-cline.customStoragePath setting points elsewhere (check the user settings.json collected by VisualStudioCode.tkape).
+# The project was archived in May 2026 in favor of a successor, but existing installs retain their task history.

--- a/Targets/Compound/AICodingAgents.tkape
+++ b/Targets/Compound/AICodingAgents.tkape
@@ -1,0 +1,28 @@
+Description: AI coding agent harnesses (Claude Code, OpenAI Codex) and the IDE that hosts their extensions
+Author: Eric Capuano
+Version: 1.0
+Id: 4760dcf6-9cf4-4098-80a6-4e5216ff7501
+RecreateDirectories: true
+Targets:
+    -
+        Name: Claude Code
+        Category: Apps
+        Path: ClaudeCode.tkape
+        Comment: 'Anthropic Claude Code CLI, VS Code extension, and Claude Desktop embedded sessions'
+    -
+        Name: OpenAI Codex
+        Category: Apps
+        Path: OpenAICodex.tkape
+        Comment: 'OpenAI Codex CLI and VS Code extension'
+    -
+        Name: Visual Studio Code
+        Category: Apps
+        Path: VisualStudioCode.tkape
+        Comment: 'Host IDE for agent extensions. Captures file history, unsaved backups, installed extension list and logs that record agent-driven edits'
+
+# Documentation
+# Agentic coding tools run shell commands, edit files, and reach network services on behalf of a user, and they keep
+# verbose local transcripts of everything they did. This compound Target gathers those transcripts and configuration for
+# the major harnesses so an examiner can reconstruct prompts, commands executed, files changed, MCP servers and hooks.
+# Add future harness Targets here (for example GitHub Copilot CLI %USERPROFILE%\.copilot\session-state\, Gemini CLI
+# %USERPROFILE%\.gemini\, Cursor, Windsurf, OpenCode) as they are created.

--- a/Targets/Compound/AICodingAgents.tkape
+++ b/Targets/Compound/AICodingAgents.tkape
@@ -1,4 +1,4 @@
-Description: AI coding agent harnesses (Claude Code, OpenAI Codex) and the IDE that hosts their extensions
+Description: AI coding agent harnesses (Claude Code, OpenAI Codex, GitHub Copilot, Gemini CLI, OpenCode, Cursor, Cline, Roo Code) and the IDE that hosts their extensions
 Author: Eric Capuano
 Version: 1.0
 Id: 4760dcf6-9cf4-4098-80a6-4e5216ff7501
@@ -15,14 +15,43 @@ Targets:
         Path: OpenAICodex.tkape
         Comment: 'OpenAI Codex CLI and VS Code extension'
     -
+        Name: GitHub Copilot
+        Category: Apps
+        Path: GitHubCopilot.tkape
+        Comment: 'GitHub Copilot CLI and Copilot Chat agent sessions in VS Code'
+    -
+        Name: Gemini CLI
+        Category: Apps
+        Path: GeminiCLI.tkape
+        Comment: 'Google Gemini CLI chat logs, prompt history and checkpoints'
+    -
+        Name: OpenCode
+        Category: Apps
+        Path: OpenCode.tkape
+        Comment: 'OpenCode session database, snapshots and configuration'
+    -
+        Name: Cursor
+        Category: Apps
+        Path: Cursor.tkape
+        Comment: 'Cursor editor agent chat history, transcripts, local history and hooks'
+    -
+        Name: Cline
+        Category: Apps
+        Path: Cline.tkape
+        Comment: 'Cline VS Code extension task histories and MCP settings'
+    -
+        Name: Roo Code
+        Category: Apps
+        Path: RooCode.tkape
+        Comment: 'Roo Code VS Code extension task histories and MCP settings'
+    -
         Name: Visual Studio Code
         Category: Apps
         Path: VisualStudioCode.tkape
-        Comment: 'Host IDE for agent extensions. Captures file history, unsaved backups, installed extension list and logs that record agent-driven edits'
+        Comment: 'Host IDE for agent extensions. Captures file history, unsaved backups, installed extension list, workspace mapping and logs that record agent-driven edits'
 
 # Documentation
 # Agentic coding tools run shell commands, edit files, and reach network services on behalf of a user, and they keep
 # verbose local transcripts of everything they did. This compound Target gathers those transcripts and configuration for
 # the major harnesses so an examiner can reconstruct prompts, commands executed, files changed, MCP servers and hooks.
-# Add future harness Targets here (for example GitHub Copilot CLI %USERPROFILE%\.copilot\session-state\, Gemini CLI
-# %USERPROFILE%\.gemini\, Cursor, Windsurf, OpenCode) as they are created.
+# Candidates for future addition once their Windows locations are verified: Windsurf, Amp, Kiro, Zed, Aider.


### PR DESCRIPTION
## Summary

Adds Targets for the AI coding agent harnesses that are showing up on developer and admin workstations, plus a compound that pulls them all together. These tools keep verbose local transcripts of every prompt, shell command, tool call and file edit they perform, along with MCP server and hook configuration. That makes them high-value evidence when an agent was used to move data, run commands, or when a compromised account or poisoned plugin drove the agent.

### Changes
- **New**: `Targets/Apps/ClaudeCode.tkape` - Claude Code CLI transcripts, prompt history, pre-edit file copies, hooks, VS Code extension storage, and Claude Desktop embedded sessions
- **New**: `Targets/Apps/OpenAICodex.tkape` - Codex CLI session rollouts, history, SQLite state, config
- **New**: `Targets/Apps/GitHubCopilot.tkape` - Copilot CLI session state and Copilot Chat sessions in VS Code
- **New**: `Targets/Apps/GeminiCLI.tkape` - Gemini CLI chat logs, prompt history, shell history, checkpoints
- **New**: `Targets/Apps/OpenCode.tkape` - OpenCode session database, snapshots, config
- **New**: `Targets/Apps/Cursor.tkape` - Cursor agent chat databases, transcripts, local history, hooks
- **New**: `Targets/Apps/Cline.tkape` and `Targets/Apps/RooCode.tkape` - task histories and MCP settings for the two VS Code extensions
- **New**: `Targets/Compound/AICodingAgents.tkape` - all of the above plus `VisualStudioCode.tkape`

Credential files for each tool (`.credentials.json`, `auth.json`, `oauth_creds.json`, `mcp-secrets`, etc.) and large binary or plugin caches are intentionally excluded. The Documentation block in each Target cites where every path came from and lists the environment variables that can relocate it.

### Testing

I don't have a Windows box handy, so I validated on a GitHub Actions `windows-latest` runner using `kape.exe` pulled from Kroll's public updater endpoint:

- `--tlist` parses the full tree with these Targets in place, and a live collection of `--target AICodingAgents` picked up 246/246 planted test files while leaving all credential/cache decoys behind: https://github.com/ecapuano/KapeFiles/actions/runs/33690505261
- Copilot CLI, Gemini CLI, OpenCode and Cursor were installed and launched on a clean runner to confirm where they actually write on Windows: https://github.com/ecapuano/KapeFiles/actions/runs/33670745528

Claude Code and Codex layouts were confirmed against live installs, with Codex also observed on the runner. Copilot Chat, Cline and Roo Code paths come from the VS Code and extension source code (globalStorage plus lowercased extension ID).

## Checklist:

- [X] I have generated a unique `GUID` for my Target(s)/Module(s)
- [X] I have placed the Target(s)/Module(s) in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the `Misc` folder or created a relevant subfolder **with justification**
- [X] I have set or updated the version of my Target(s)/Module(s)
- [X] I have verified that KAPE parses the Target(s)/Module(s) successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors
- [X] I have validated my Target(s)/Module(s) against test data and verified they are working as intended
- [X] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed `N/A` underneath the Documentation header
- [X] For Targets, I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format
- [ ] For Modules, I have consulted either the [Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleGuide.guide), [Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/ModuleTemplate.template), [Compound Module Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleGuide.guide), or [Compound Module Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Modules/CompoundModuleTemplate.template) to ensure my Module(s) follow the same format
